### PR TITLE
Remove default headers

### DIFF
--- a/GovUK.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/GovUK.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -3,13 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>FILEHEADER</key>
-	<string>
-// GOV.UK
-//
-// Copyright © ___YEAR___ ___ORGANIZATIONNAME___.
-// All Rights Reserved.
-//</string>
-	<key>ORGANIZATIONNAME</key>
-	<string>Government Digital Services</string>
+	<string></string>
 </dict>
 </plist>

--- a/Production/govuk_ios/SupportingFiles/AppDelegate.swift
+++ b/Production/govuk_ios/SupportingFiles/AppDelegate.swift
@@ -1,10 +1,3 @@
-//
-// GOV.UK
-//
-// Copyright © 2024 Government Digital Services.
-// All Rights Reserved.
-//
-
 import UIKit
 
 @main

--- a/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
+++ b/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
@@ -1,10 +1,3 @@
-//
-// GOV.UK
-//
-// Copyright © 2024 Government Digital Services.
-// All Rights Reserved.
-//
-
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {

--- a/Production/govuk_ios/ViewControllers/ViewController.swift
+++ b/Production/govuk_ios/ViewControllers/ViewController.swift
@@ -1,10 +1,3 @@
-//
-// GOV.UK
-//
-// Copyright © 2024 Government Digital Services.
-// All Rights Reserved.
-//
-
 import UIKit
 
 class ViewController: UIViewController {

--- a/Tests/govuk_ios/govuk_ios_ui_tests/GovUKUITests.swift
+++ b/Tests/govuk_ios/govuk_ios_ui_tests/GovUKUITests.swift
@@ -1,10 +1,3 @@
-//
-// GOV.UK
-//
-// Copyright © 2024 Government Digital Services.
-// All Rights Reserved.
-//
-
 import XCTest
 
 final class GovUKUITests: XCTestCase {

--- a/Tests/govuk_ios/govuk_ios_ui_tests/GovUKUITestsLaunchTests.swift
+++ b/Tests/govuk_ios/govuk_ios_ui_tests/GovUKUITestsLaunchTests.swift
@@ -1,10 +1,3 @@
-//
-// GOV.UK
-//
-// Copyright © 2024 Government Digital Services.
-// All Rights Reserved.
-//
-
 import XCTest
 
 final class GovUKUITestsLaunchTests: XCTestCase {

--- a/Tests/govuk_ios/govuk_ios_unit_tests/GovUKTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/GovUKTests.swift
@@ -1,10 +1,3 @@
-//
-// GOV.UK
-//
-// Copyright © 2024 Government Digital Services.
-// All Rights Reserved.
-//
-
 import XCTest
 
 @testable import govuk_ios


### PR DESCRIPTION
Removing all headers and the template.

This still leaves an empty comment at the top of new files that needs to be deleted when creating a new file. 
It's better to have an empty comment than the current header in case someone forgets to delete it.