### PR TITLE
Set swiftlint to run on incremental builds

### DIFF
--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -580,6 +580,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		5D451E212BD69D6600673BC1 /* Lint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
Currently SwiftLint is not running on incremental builds which means that we are only identifying listing problems when they hit the pipeline runner. Changing this configuration ensures that the linter will run on all builds.