### PR TITLE
GOVUKAPP-491: added UIViewRepresentable wrapper around GDSCommon button

### DIFF
--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		5DFFA9762BFF950A00B02042 /* LaunchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DFFA9752BFF950A00B02042 /* LaunchCoordinatorTests.swift */; };
 		961743B32C219A5D00A94378 /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961743B22C219A5D00A94378 /* PrimaryButton.swift */; };
 		961743B62C219A9900A94378 /* GDSCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 961743B52C219A9900A94378 /* GDSCommon */; };
+		96E1FC292C24607400818A8B /* ButtonWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E1FC282C24607400818A8B /* ButtonWrapperTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -158,6 +159,7 @@
 		5DFFA9732BFF8D0F00B02042 /* AppCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorTests.swift; sourceTree = "<group>"; };
 		5DFFA9752BFF950A00B02042 /* LaunchCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchCoordinatorTests.swift; sourceTree = "<group>"; };
 		961743B22C219A5D00A94378 /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
+		96E1FC282C24607400818A8B /* ButtonWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonWrapperTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -391,6 +393,7 @@
 		5DAD718D2BD250DF0075F648 /* govuk_ios_unit_tests */ = {
 			isa = PBXGroup;
 			children = (
+				96E1FC272C24605900818A8B /* ViewComponents */,
 				5DD6EFFB2BFF546000C2D79B /* Mocks */,
 				5DD6EFFC2BFF546900C2D79B /* Specs */,
 			);
@@ -503,6 +506,14 @@
 				961743B22C219A5D00A94378 /* PrimaryButton.swift */,
 			);
 			path = UIViewComponents;
+			sourceTree = "<group>";
+		};
+		96E1FC272C24605900818A8B /* ViewComponents */ = {
+			isa = PBXGroup;
+			children = (
+				96E1FC282C24607400818A8B /* ButtonWrapperTests.swift */,
+			);
+			path = ViewComponents;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -767,6 +778,7 @@
 				5D4F97E72BFF7222002CBDDE /* MockNavigationController.swift in Sources */,
 				5D41DB582C08651E0011E691 /* BaseViewControllerTests.swift in Sources */,
 				5DFFA9742BFF8D0F00B02042 /* AppCoordinatorTests.swift in Sources */,
+				96E1FC292C24607400818A8B /* ButtonWrapperTests.swift in Sources */,
 				5D41DB782C08AE950011E691 /* MockDeeplinkService.swift in Sources */,
 				5D41DB7A2C08AFC00011E691 /* TestServiceTests.swift in Sources */,
 			);

--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		5DC325622BFF252900CB590B /* BaseCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC325612BFF252900CB590B /* BaseCoordinatorTests.swift */; };
 		5DFFA9742BFF8D0F00B02042 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DFFA9732BFF8D0F00B02042 /* AppCoordinatorTests.swift */; };
 		5DFFA9762BFF950A00B02042 /* LaunchCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DFFA9752BFF950A00B02042 /* LaunchCoordinatorTests.swift */; };
+		961743B32C219A5D00A94378 /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961743B22C219A5D00A94378 /* PrimaryButton.swift */; };
+		961743B62C219A9900A94378 /* GDSCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 961743B52C219A9900A94378 /* GDSCommon */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -155,6 +157,7 @@
 		5DDBCA942C073ECB00A6ADBF /* GovUK.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = GovUK.xctestplan; sourceTree = "<group>"; };
 		5DFFA9732BFF8D0F00B02042 /* AppCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorTests.swift; sourceTree = "<group>"; };
 		5DFFA9752BFF950A00B02042 /* LaunchCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchCoordinatorTests.swift; sourceTree = "<group>"; };
+		961743B22C219A5D00A94378 /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -170,6 +173,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				961743B62C219A9900A94378 /* GDSCommon in Frameworks */,
 				5D2129E02BDF98E100142E46 /* Services in Frameworks */,
 				5D7F267E2C0F0EF000842090 /* Factory in Frameworks */,
 				5D99312E2BF7642C0036C8FB /* Coordination in Frameworks */,
@@ -369,6 +373,7 @@
 		5DAD71762BD250DB0075F648 /* govuk_ios */ = {
 			isa = PBXGroup;
 			children = (
+				961743B12C219A4200A94378 /* UIViewComponents */,
 				5D4F97E92BFF771A002CBDDE /* Builders */,
 				5D2129E92BDFA00E00142E46 /* Coordinators */,
 				5D41DB6A2C088CA30011E691 /* DataStores */,
@@ -492,6 +497,14 @@
 			path = Specs;
 			sourceTree = "<group>";
 		};
+		961743B12C219A4200A94378 /* UIViewComponents */ = {
+			isa = PBXGroup;
+			children = (
+				961743B22C219A5D00A94378 /* PrimaryButton.swift */,
+			);
+			path = UIViewComponents;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -537,6 +550,7 @@
 				5D1353AA2BE0D75000414441 /* Homepage */,
 				5D99312D2BF7642C0036C8FB /* Coordination */,
 				5D7F267D2C0F0EF000842090 /* Factory */,
+				961743B52C219A9900A94378 /* GDSCommon */,
 			);
 			productName = GovUK;
 			productReference = 5DAD71742BD250DB0075F648 /* govuk_ios.app */;
@@ -623,6 +637,7 @@
 				5D99312C2BF7642C0036C8FB /* XCRemoteSwiftPackageReference "mobile-ios-coordination" */,
 				5D89226D2C071FE70019FBD7 /* XCRemoteSwiftPackageReference "ios-snapshot-test-case" */,
 				5D7F267C2C0F0EF000842090 /* XCRemoteSwiftPackageReference "Factory" */,
+				961743B42C219A9900A94378 /* XCRemoteSwiftPackageReference "mobile-ios-common" */,
 			);
 			productRefGroup = 5DAD71752BD250DB0075F648 /* Products */;
 			projectDirPath = "";
@@ -720,6 +735,7 @@
 				5D1353AD2BE0D8DA00414441 /* ColorCoordinator.swift in Sources */,
 				5D54A82C2BFC8EF1003D0C21 /* LaunchCoordinator.swift in Sources */,
 				5D1353B02BE0D9B800414441 /* UINavigationController+Convenience.swift in Sources */,
+				961743B32C219A5D00A94378 /* PrimaryButton.swift in Sources */,
 				5D41DB632C08755F0011E691 /* TestService.swift in Sources */,
 				5D41DB732C08981A0011E691 /* DeeplinkService.swift in Sources */,
 				5D54A8322BFCBF50003D0C21 /* main.swift in Sources */,
@@ -1182,6 +1198,14 @@
 				kind = branch;
 			};
 		};
+		961743B42C219A9900A94378 /* XCRemoteSwiftPackageReference "mobile-ios-common" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-common.git";
+			requirement = {
+				branch = "feature/govukapp-491-button-action-init";
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1214,6 +1238,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5D99312C2BF7642C0036C8FB /* XCRemoteSwiftPackageReference "mobile-ios-coordination" */;
 			productName = Coordination;
+		};
+		961743B52C219A9900A94378 /* GDSCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 961743B42C219A9900A94378 /* XCRemoteSwiftPackageReference "mobile-ios-common" */;
+			productName = GDSCommon;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -1202,8 +1202,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/govuk-one-login/mobile-ios-common.git";
 			requirement = {
-				branch = "feature/govukapp-491-button-action-init";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
+++ b/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
@@ -7,14 +7,13 @@ struct PrimaryButton: UIViewRepresentable {
     let icon: String?
 
     func makeUIView(context: Context) -> RoundedButton {
-        let button = RoundedButton()
+        let button = RoundedButton(action: action)
 
         if let icon {
             button.icon = icon
         }
 
         button.setTitle(title, for: .normal)
-        button.addAction(action, for: .touchUpInside)
 
         return button
     }

--- a/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
+++ b/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
@@ -7,6 +7,10 @@ protocol WrappableButton: UIButton {
     init(action: UIAction)
 }
 
+extension WrappableButton {
+    var icon: String? { nil }
+}
+
 extension SecondaryButton: WrappableButton {}
 
 struct ButtonWrapper<WrappedButton: WrappableButton>: UIViewRepresentable {

--- a/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
+++ b/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
@@ -1,7 +1,9 @@
 import GDSCommon
 import SwiftUI
 
-protocol WrappableButton: SecondaryButton {
+protocol WrappableButton: UIButton {
+    var icon: String? { get set }
+
     init(action: UIAction)
 }
 

--- a/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
+++ b/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
@@ -1,0 +1,36 @@
+import GDSCommon
+import SwiftUI
+
+struct PrimaryButton: UIViewRepresentable {
+    private let action: UIAction
+    let title: String
+    let icon: String?
+
+    func makeUIView(context: Context) -> RoundedButton {
+        let button = RoundedButton()
+
+        if let icon {
+            button.icon = icon
+        }
+
+        button.setTitle(title, for: .normal)
+        button.addAction(action, for: .touchUpInside)
+
+        return button
+    }
+
+    func updateUIView(_ uiView: RoundedButton, context: Context) { }
+
+    func makeCoordinator() -> Self.Coordinator { }
+
+    init(title: String,
+         icon: String? = nil,
+         action:
+         @escaping () -> Void) {
+        self.title = title
+        self.icon = icon
+        self.action = UIAction { _ in
+            action()
+        }
+    }
+}

--- a/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
+++ b/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
@@ -1,13 +1,20 @@
 import GDSCommon
 import SwiftUI
 
-struct PrimaryButton: UIViewRepresentable {
+protocol WrappableButton: SecondaryButton {
+    init(action: UIAction)
+}
+
+extension SecondaryButton: WrappableButton {}
+
+struct ButtonWrapper<WrappedButton: WrappableButton>: UIViewRepresentable {
     private let action: UIAction
+
     let title: String
     let icon: String?
 
-    func makeUIView(context: Context) -> RoundedButton {
-        let button = RoundedButton(action: action)
+    func makeUIView(context: Context) -> WrappedButton {
+        let button = WrappedButton(action: action)
 
         if let icon {
             button.icon = icon
@@ -18,7 +25,7 @@ struct PrimaryButton: UIViewRepresentable {
         return button
     }
 
-    func updateUIView(_ uiView: RoundedButton, context: Context) { }
+    func updateUIView(_ uiView: WrappedButton, context: Context) { }
 
     func makeCoordinator() -> Self.Coordinator { }
 

--- a/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
+++ b/Production/govuk_ios/UIViewComponents/PrimaryButton.swift
@@ -19,6 +19,17 @@ struct ButtonWrapper<WrappedButton: WrappableButton>: UIViewRepresentable {
     let title: String
     let icon: String?
 
+    init(title: String,
+         icon: String? = nil,
+         action:
+         @escaping () -> Void) {
+        self.title = title
+        self.icon = icon
+        self.action = UIAction { _ in
+            action()
+        }
+    }
+
     func makeUIView(context: Context) -> WrappedButton {
         let button = WrappedButton(action: action)
 
@@ -31,18 +42,11 @@ struct ButtonWrapper<WrappedButton: WrappableButton>: UIViewRepresentable {
         return button
     }
 
-    func updateUIView(_ uiView: WrappedButton, context: Context) { }
+    func updateUIView(_ uiView: WrappedButton, context: Context) {
+        // required for protocol conformance
+    }
 
-    func makeCoordinator() -> Self.Coordinator { }
-
-    init(title: String,
-         icon: String? = nil,
-         action:
-         @escaping () -> Void) {
-        self.title = title
-        self.icon = icon
-        self.action = UIAction { _ in
-            action()
-        }
+    func makeCoordinator() -> Self.Coordinator {
+        // required for protocol conformance
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/ViewComponents/ButtonWrapperTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/ViewComponents/ButtonWrapperTests.swift
@@ -1,0 +1,44 @@
+import GDSCommon
+@testable import govuk_ios
+import SwiftUI
+import XCTest
+
+final class ButtonWrapperTests: XCTestCase {
+    var sut: (any View)!
+
+    override func setUp() {
+        super.setUp()
+        
+        sut = ButtonWrapper<SecondaryButton>(title: "test button") {
+            // some action here
+        }
+    }
+
+    override func tearDown() {
+        sut = nil
+
+        super.tearDown()
+    }
+
+    func test_buttonCreated() {
+        guard let button = sut as? ButtonWrapper<SecondaryButton> else {
+            XCTFail("button test failed")
+            return
+        }
+
+        XCTAssertNotNil(button)
+    }
+
+    func test_buttonCreatedWithIcon() {
+        sut = ButtonWrapper<SecondaryButton>(title: "test button", icon: "arrow.up.right") {
+            // some action here
+        }
+
+        guard let button = sut as? ButtonWrapper<SecondaryButton> else {
+            XCTFail("button test failed")
+            return
+        }
+
+        XCTAssertNotNil(button)
+    }
+}


### PR DESCRIPTION
This implements a protocol `WrappableButton` and then a generic `UIViewRepresentable` for buttons that conform to that protocol.

This means a single wrapper can be used for many different `UIButton` sub-classes as long as they conform to the `WrappableButton` protocol.

In use it would look something like this:

```
ButtonWrapper<RoundedButton>(title: "some button title") {
                    // button action goes here
                }
```