### PR TITLE
Added Swift Testing

### DIFF
--- a/Production/govuk_ios/Builders/ViewControllerBuilder.swift
+++ b/Production/govuk_ios/Builders/ViewControllerBuilder.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 
 class ViewControllerBuilder {
+    @MainActor
     func driving(showPermitAction: @escaping () -> Void,
                  presentPermitAction: @escaping () -> Void) -> UIViewController {
         let viewModel = TestViewModel(
@@ -17,6 +18,7 @@ class ViewControllerBuilder {
         )
     }
 
+    @MainActor
     func launch(completion: @escaping () -> Void) -> UIViewController {
         let viewModel = LaunchViewModel(
             animationCompleted: completion
@@ -26,6 +28,7 @@ class ViewControllerBuilder {
         )
     }
 
+    @MainActor
     func permit(permitId: String,
                 finishAction: @escaping () -> Void) -> UIViewController {
         let viewModel = TestViewModel(
@@ -41,6 +44,7 @@ class ViewControllerBuilder {
         )
     }
 
+    @MainActor
     func home(searchButtonPrimaryAction: @escaping () -> Void,
               configService: AppConfigServiceInterface) -> UIViewController {
         let viewModel = HomeViewModel(
@@ -52,6 +56,7 @@ class ViewControllerBuilder {
         )
     }
 
+    @MainActor
     func settings(analyticsService: AnalyticsServiceInterface) -> UIViewController {
         let viewModel = SettingsViewModel(
             analyticsService: analyticsService,
@@ -63,6 +68,7 @@ class ViewControllerBuilder {
         )
     }
 
+    @MainActor
     func search(analyticsService: AnalyticsServiceInterface,
                 dismissAction: @escaping () -> Void) -> UIViewController {
         let viewModel = SearchViewModel(

--- a/Production/govuk_ios/Model/Analytics/TrackableScreen.swift
+++ b/Production/govuk_ios/Model/Analytics/TrackableScreen.swift
@@ -2,10 +2,10 @@ import Foundation
 import UIKit
 
 protocol TrackableScreen {
-    var trackingName: String { get }
-    var trackingClass: String { get }
-    var trackingTitle: String? { get }
-    var trackingLanguage: String { get }
+    nonisolated var trackingName: String { get }
+    nonisolated var trackingClass: String { get }
+    nonisolated var trackingTitle: String? { get }
+    nonisolated var trackingLanguage: String { get }
 }
 
 extension TrackableScreen {

--- a/Production/govuk_ios/ViewControllers/BaseViewController.swift
+++ b/Production/govuk_ios/ViewControllers/BaseViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Foundation
 
+@MainActor
 class BaseViewController: UIViewController {
     @Inject(\.analyticsService) private(set) var analyticsService: AnalyticsServiceInterface
 

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/AnalyticsConsentViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/AnalyticsConsentViewControllerSnapshotTests.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 @testable import govuk_ios
 
+@MainActor
 final class AnalyticsConsentViewControllerSnapshotTests: SnapshotTestCase {
     func test_loadInNavigationController_light_rendersCorrectly() {
         VerifySnapshotInNavigationController(

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/HomeViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/HomeViewControllerSnapshotTests.swift
@@ -4,6 +4,7 @@ import UIKit
 
 @testable import govuk_ios
 
+@MainActor
 class HomeViewControllerSnapshotTests: SnapshotTestCase {
     func test_loadInNavigationController_light_rendersCorrectly() {
         VerifySnapshotInNavigationController(

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/LaunchViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/LaunchViewControllerSnapshotTests.swift
@@ -6,11 +6,12 @@ import Factory
 
 @testable import govuk_ios
 
+@MainActor
 class LaunchViewControllerSnapshotTests: SnapshotTestCase {
     private var mockAccessibilityManager: MockAccessibilityManager!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         mockAccessibilityManager = MockAccessibilityManager()
         Container.shared.accessibilityManager.register(
             factory: {

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SearchViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SearchViewControllerSnapshotTests.swift
@@ -4,6 +4,7 @@ import UIKit
 
 @testable import govuk_ios
 
+@MainActor
 class SearchViewControllerSnapshotTests: SnapshotTestCase {
     func test_loadInNavigationController_light_rendersCorrectly() {
         VerifySnapshotInNavigationController(

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SettingsViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SettingsViewControllerSnapshotTests.swift
@@ -4,6 +4,7 @@ import UIKit
 
 @testable import govuk_ios
 
+@MainActor
 class SettingsViewControllerSnapshotTests: SnapshotTestCase {
     func test_loadInNavigationController_light_rendersCorrectly() {
         VerifySnapshotInNavigationController(

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/MockBaseViewController.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/MockBaseViewController.swift
@@ -2,6 +2,7 @@ import Foundation
 
 @testable import govuk_ios
 
+@MainActor
 class MockBaseViewController: BaseViewController,
                               TrackableScreen {
     var trackingName: String { "test_mock_tracking_name" }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 @testable import govuk_ios
 
+@MainActor
 class ViewControllerBuilderTests: XCTestCase {
     func test_driving_returnsExpectedResult() {
         let subject = ViewControllerBuilder()

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Clients/FirebaseClientTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Clients/FirebaseClientTests.swift
@@ -1,12 +1,14 @@
 import Foundation
-import XCTest
+import Testing
 
 import FirebaseAnalytics
 
 @testable import govuk_ios
 
-class FirebaseClientTests: XCTestCase {
+@Suite(.serialized)
+struct FirebaseClientTests {
 
+    @Test
     func test_launch_configuresFirebaseApp() {
         let mockApp = MockFirebaseApp.self
         let mockAnalytics = MockFirebaseAnalytics.self
@@ -18,9 +20,10 @@ class FirebaseClientTests: XCTestCase {
         MockFirebaseApp._configureCalled = false
         sut.launch()
 
-        XCTAssertTrue(mockApp._configureCalled)
+        #expect(mockApp._configureCalled)
     }
 
+    @Test
     func test_setEnabled_true_enablesAnalytics() {
         let mockApp = MockFirebaseApp.self
         let mockAnalytics = MockFirebaseAnalytics.self
@@ -32,9 +35,10 @@ class FirebaseClientTests: XCTestCase {
         mockAnalytics.clearValues()
         sut.setEnabled(enabled: true)
 
-        XCTAssertEqual(mockAnalytics._setAnalyticsCollectionEnabledReveivedEnabled, true)
+        #expect(mockAnalytics._setAnalyticsCollectionEnabledReveivedEnabled == true)
     }
 
+    @Test
     func test_setEnabled_false_disablesAnalytics() {
         let mockApp = MockFirebaseApp.self
         let mockAnalytics = MockFirebaseAnalytics.self
@@ -46,9 +50,10 @@ class FirebaseClientTests: XCTestCase {
         mockAnalytics.clearValues()
         sut.setEnabled(enabled: false)
 
-        XCTAssertEqual(mockAnalytics._setAnalyticsCollectionEnabledReveivedEnabled, false)
+        #expect(mockAnalytics._setAnalyticsCollectionEnabledReveivedEnabled == false)
     }
 
+    @Test
     func test_trackEvent_noParams_tracksExpectedEvent() {
         let mockApp = MockFirebaseApp.self
         let mockAnalytics = MockFirebaseAnalytics.self
@@ -63,10 +68,11 @@ class FirebaseClientTests: XCTestCase {
         )
         sut.track(event: expectedEvent)
 
-        XCTAssertEqual(mockAnalytics._logEventReceivedEventName, expectedName)
-        XCTAssertEqual(mockAnalytics._logEventReceivedEventParameters?.isEmpty, true)
+        #expect(mockAnalytics._logEventReceivedEventName == expectedName)
+        #expect(mockAnalytics._logEventReceivedEventParameters?.isEmpty == true)
     }
 
+    @Test
     func test_trackEvent_withParams_tracksExpectedEvent() {
         let mockApp = MockFirebaseApp.self
         let mockAnalytics = MockFirebaseAnalytics.self
@@ -87,12 +93,14 @@ class FirebaseClientTests: XCTestCase {
         mockAnalytics.clearValues()
         sut.track(event: expectedEvent)
 
-        XCTAssertEqual(mockAnalytics._logEventReceivedEventName, expectedName)
+        #expect(mockAnalytics._logEventReceivedEventName == expectedName)
         let receivedParams = mockAnalytics._logEventReceivedEventParameters
-        XCTAssertEqual(receivedParams?.count, 1)
-        XCTAssertEqual(receivedParams?["test_param"] as? String, expectedValue)
+        #expect(receivedParams?.count == 1)
+        #expect(receivedParams?["test_param"] as? String == expectedValue)
     }
 
+    @Test
+    @MainActor
     func test_trackScreen_tracksExpectedEvent() {
         let mockApp = MockFirebaseApp.self
         let mockAnalytics = MockFirebaseAnalytics.self
@@ -106,13 +114,13 @@ class FirebaseClientTests: XCTestCase {
         mockAnalytics.clearValues()
         sut.track(screen: expectedScreen)
 
-        XCTAssertEqual(mockAnalytics._logEventReceivedEventName, AnalyticsEventScreenView)
+        #expect(mockAnalytics._logEventReceivedEventName == AnalyticsEventScreenView)
         let receivedParams = mockAnalytics._logEventReceivedEventParameters
-        XCTAssertEqual(receivedParams?.count, 4)
-        XCTAssertEqual(receivedParams?[AnalyticsParameterScreenName] as? String, expectedScreen.trackingName)
-        XCTAssertEqual(receivedParams?[AnalyticsParameterScreenClass] as? String, expectedScreen.trackingClass)
-        XCTAssertEqual(receivedParams?["screen_title"] as? String, expectedTitle)
-        XCTAssertEqual(receivedParams?["language"] as? String, expectedScreen.trackingLanguage)
+        #expect(receivedParams?.count == 4)
+        #expect(receivedParams?[AnalyticsParameterScreenName] as? String == expectedScreen.trackingName)
+        #expect(receivedParams?[AnalyticsParameterScreenClass] as? String == expectedScreen.trackingClass)
+        #expect(receivedParams?["screen_title"] as? String == expectedTitle)
+        #expect(receivedParams?["language"] as? String == expectedScreen.trackingLanguage)
     }
 }
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/BaseCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/BaseCoordinatorTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import govuk_ios
 
+@MainActor
 class BaseCoordinatorTests: XCTestCase {
-    @MainActor
     func test_init_setsPresentationController() {
         let navigationController = UINavigationController()
         let subject = BaseCoordinator(navigationController: navigationController)
@@ -12,7 +12,6 @@ class BaseCoordinatorTests: XCTestCase {
         XCTAssert(navigationController.presentationController?.delegate === subject)
     }
 
-    @MainActor
     func test_presentationControllerDidDismiss_callsFinish() {
         let navigationController = UINavigationController()
         let subject = TestCoordinator(navigationController: navigationController)
@@ -33,7 +32,6 @@ class BaseCoordinatorTests: XCTestCase {
         wait(for: [expectation])
     }
 
-    @MainActor
     func test_push_addsViewControllerToStack() {
         let navigationController = UINavigationController()
         let subject = TestCoordinator(navigationController: navigationController)
@@ -49,7 +47,6 @@ class BaseCoordinatorTests: XCTestCase {
         XCTAssert(navigationController.viewControllers.contains(viewController2))
     }
 
-    @MainActor
     func test_setViewController_addsViewControllerToStack() {
         let navigationController = UINavigationController()
         let subject = TestCoordinator(navigationController: navigationController)
@@ -64,7 +61,6 @@ class BaseCoordinatorTests: XCTestCase {
         XCTAssert(navigationController.viewControllers.contains(viewController2))
     }
 
-    @MainActor
     func test_setViewControllers_addsViewControllerToStack() {
         let navigationController = UINavigationController()
         let subject = TestCoordinator(navigationController: navigationController)
@@ -85,7 +81,6 @@ class BaseCoordinatorTests: XCTestCase {
         XCTAssertEqual(navigationController.viewControllers.count, 2)
     }
 
-    @MainActor
     func test_viewControllerPopped_remainingViewControllers_doesNothing() {
         let navigationController = UINavigationController()
         let subject = TestCoordinator(navigationController: navigationController)
@@ -115,7 +110,6 @@ class BaseCoordinatorTests: XCTestCase {
         )
     }
 
-    @MainActor
     func test_viewControllerPopped_finalViewController_callsFinish() {
         let parentCoordinator = MockBaseCoordinator()
         let navigationController = parentCoordinator.root
@@ -141,7 +135,6 @@ class BaseCoordinatorTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    @MainActor
     func test_startCoordinator_startsCoordinator() {
         let navigationController = UINavigationController()
         let child = MockBaseCoordinator(navigationController: navigationController)
@@ -152,7 +145,6 @@ class BaseCoordinatorTests: XCTestCase {
         XCTAssertTrue(child._startCalled)
     }
 
-    @MainActor
     func test_presentCoordinator_startsCoordinator() {
         let childNavigationController = UINavigationController()
         let child = MockBaseCoordinator(navigationController: childNavigationController)
@@ -168,7 +160,6 @@ class BaseCoordinatorTests: XCTestCase {
         XCTAssertEqual(navigationController._presentedViewController, childNavigationController)
     }
 
-    @MainActor
     func test_dismiss_modal_callsDismiss() {
         let mockNavigationController = MockNavigationController()
         let subject = TestCoordinator(navigationController: mockNavigationController)
@@ -184,7 +175,6 @@ class BaseCoordinatorTests: XCTestCase {
         XCTAssert(mockNavigationController._dismissCalled)
     }
 
-    @MainActor
     func test_dismiss_pushed_callsPop() {
         let mockNavigationController = MockNavigationController()
         let subject = TestCoordinator(navigationController: mockNavigationController)

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/BaseCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/BaseCoordinatorTests.swift
@@ -131,8 +131,7 @@ class BaseCoordinatorTests: XCTestCase {
         }
 
         navigationController.popViewController(animated: false)
-
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: 1.5)
     }
 
     func test_startCoordinator_startsCoordinator() {

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Extensions/UIKit/UIViewController+ExtensionsTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Extensions/UIKit/UIViewController+ExtensionsTests.swift
@@ -1,18 +1,22 @@
 import Foundation
 
-import XCTest
+import Testing
 
 @testable import govuk_ios
 
-class UIViewController_ExtensionsTests: XCTestCase {
-    func test_viewWillReAppear_animated_callsTransitions() {
+@MainActor
+@Suite
+struct UIViewController_ExtensionsTests {
+
+    @Test
+    func viewWillReAppear_animated_callsTransitions() {
         let subject = MockBaseViewController()
         subject.viewWillReAppear(
             isAppearing: true,
             animated: false
         )
 
-        XCTAssertEqual(subject._receivedBeginAppearanceTransitionAnimated, false)
-        XCTAssertTrue(subject._endAppearanceTransitionCalled)
+        #expect(subject._receivedBeginAppearanceTransitionAnimated == false)
+        #expect(subject._endAppearanceTransitionCalled)
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/AnalyticsServiceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/AnalyticsServiceTests.swift
@@ -84,6 +84,7 @@ final class AnalyticsServiceTests: XCTestCase {
         XCTAssertEqual(mockAnalyticsClient._trackEventReceivedEvents.count, 1)
     }
 
+    @MainActor
     func test_trackScreen_tracksScreen() {
         let subject = AnalyticsService(
             clients: [mockAnalyticsClient],

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/BaseViewControllerTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/BaseViewControllerTests.swift
@@ -6,6 +6,7 @@ import Factory
 
 @testable import govuk_ios
 
+@MainActor
 class BaseViewControllerTests: XCTestCase {
 
     func test_preferredStatusBarStyle_returnsExpectedValue() {

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/SearchViewControllerTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/SearchViewControllerTests.swift
@@ -1,14 +1,17 @@
 import UIKit
 import Foundation
-import XCTest
+import Testing
 
 import Factory
 
 @testable import govuk_ios
 
-class SearchViewControllerTests: XCTestCase {
-    
-    func test_viewDidAppear_tracksScreen() {
+@MainActor
+@Suite
+struct SearchViewControllerTests {
+
+    @Test
+    func viewDidAppear_tracksScreen() {
         let mockAnalyticsService = MockAnalyticsService()
         Container.shared.analyticsService.register {
             mockAnalyticsService
@@ -21,8 +24,8 @@ class SearchViewControllerTests: XCTestCase {
         subject.viewDidAppear(false)
 
         let screens = mockAnalyticsService._trackScreenReceivedScreens
-        XCTAssertEqual(screens.count, 1)
-        XCTAssertEqual(screens.first?.trackingName, subject.trackingName)
-        XCTAssertEqual(screens.first?.trackingClass, subject.trackingClass)
+        #expect(screens.count == 1)
+        #expect(screens.first?.trackingName == subject.trackingName)
+        #expect(screens.first?.trackingClass == subject.trackingClass)
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/SettingsViewControllerTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/SettingsViewControllerTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 @testable import govuk_ios
 
+@MainActor
 class SettingsViewControllerTests: XCTestCase {
     func test_settings_hasCorrectBackgroundColor() {
         let viewModel = SettingsViewModel(


### PR DESCRIPTION
There are some unit tests that would benefit from running `.serialized` because they use static vars to assert against.

Added Swift Testing to achieve this without making all tests run in serial.