### PR TITLE
Fix search error link bug

### DIFF
--- a/Production/govuk_ios/Views/Search/SearchErrorView.swift
+++ b/Production/govuk_ios/Views/Search/SearchErrorView.swift
@@ -60,8 +60,7 @@ class SearchErrorView: UIView {
         errorDescription.text = errorDesc
         errorLink = link
 
-        guard link != nil
-        else { return errorLinkButton.isHidden = true }
+        errorLinkButton.isHidden = (link == nil)
 
         var errorLinkButtonButtonViewModel: GOVUKButton.ButtonViewModel {
             .init(


### PR DESCRIPTION
Prevously, if the user met an error screen with no link, e.g no results and then straight after returned a generic error with a link, the link would still be hidden. We now set the hidden flag to false when there is a link.