### PR TITLE
GOVUKAPP-589 Global ON / OFF switch: Ignore bottom safe area

### DIFF
--- a/Production/govuk_ios/SwiftUIViews/AppUnavailableContainerView.swift
+++ b/Production/govuk_ios/SwiftUIViews/AppUnavailableContainerView.swift
@@ -42,7 +42,7 @@ struct AppUnavailableContainerView: View {
             .frame(minHeight: 44, idealHeight: 44)
             .padding([.top, .horizontal], 16)
             .padding(.bottom, 32)
-        }.edgesIgnoringSafeArea(.bottom)
+        }.edgesIgnoringSafeArea([.bottom, .horizontal])
     }
 }
 

--- a/Production/govuk_ios/SwiftUIViews/AppUnavailableContainerView.swift
+++ b/Production/govuk_ios/SwiftUIViews/AppUnavailableContainerView.swift
@@ -42,7 +42,7 @@ struct AppUnavailableContainerView: View {
             .frame(minHeight: 44, idealHeight: 44)
             .padding([.top, .horizontal], 16)
             .padding(.bottom, 32)
-        }
+        }.edgesIgnoringSafeArea(.bottom)
     }
 }
 

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.AppUnavailableViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.AppUnavailableViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34572383bfe5ddc4231d04472b6aefee91d2cea876a1e83b60b339d4bcb0ad13
-size 109108
+oid sha256:769ba50f88f117b01a11605b6b738b7e7b100faa8ed5fd4c375e5e72b632a9dc
+size 108996

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.AppUnavailableViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.AppUnavailableViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7b6bc08ac6944daa1a1e5222d382c56715d9bd104ee88c7e2b3f469f5b84557
-size 100995
+oid sha256:bbb37ba2b91593b8d85ea29eb61ca8b3253793df9e1f0e767d7122d267c695dc
+size 100861


### PR DESCRIPTION
Ignore bottom safe area so view elements are positioned inline with designs

[Jira link](https://govukverify.atlassian.net/browse/GOVUKAPP-589)

[Figma link](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=710-16944&node-type=frame&t=EbzBkYwf47XOvILr-0)

![test_loadInNavigationController_dark_rendersCorrectly@3x](https://github.com/user-attachments/assets/85797961-f36d-4491-8de2-3fbeffd5a391)

![test_loadInNavigationController_light_rendersCorrectly@3x](https://github.com/user-attachments/assets/15fb3e9b-8e88-4e93-b75e-2dcb219b7b7f)