### PR TITLE
Feature/govukapp 763 edit topics

### DIFF
--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -278,8 +278,10 @@
 		9685F82D2C78DE7E00C33614 /* GroupedListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9685F82C2C78DE7E00C33614 /* GroupedListSection.swift */; };
 		9685F82F2C78DF7000C33614 /* GroupedListSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9685F82E2C78DF7000C33614 /* GroupedListSectionView.swift */; };
 		96DE82882C7E25ED0071D792 /* SinglePixelLineHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DE82872C7E25ED0071D792 /* SinglePixelLineHelper.swift */; };
+		D028CCF42CB4247100742620 /* TopicsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF32CB4247100742620 /* TopicsRepository.swift */; };
+		D028CCF62CB9619B00742620 /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF52CB9619B00742620 /* Topic.swift */; };
 		D04191782CA57A6F0034722A /* TopicsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191772CA57A6F0034722A /* TopicsService.swift */; };
-		D04191802CA595400034722A /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D041917F2CA595400034722A /* Topic.swift */; };
+		D04191802CA595400034722A /* TopicResponseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D041917F2CA595400034722A /* TopicResponseItem.swift */; };
 		D04191842CA5B06D0034722A /* TopicsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191832CA5B0650034722A /* TopicsServiceTests.swift */; };
 		D04191862CA6A59D0034722A /* TopicsServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191852CA6A5910034722A /* TopicsServiceClient.swift */; };
 		D046511D2C933FE600F47C66 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D046511C2C933FE600F47C66 /* String+Extensions.swift */; };
@@ -606,8 +608,10 @@
 		9685F82C2C78DE7E00C33614 /* GroupedListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedListSection.swift; sourceTree = "<group>"; };
 		9685F82E2C78DF7000C33614 /* GroupedListSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedListSectionView.swift; sourceTree = "<group>"; };
 		96DE82872C7E25ED0071D792 /* SinglePixelLineHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglePixelLineHelper.swift; sourceTree = "<group>"; };
+		D028CCF32CB4247100742620 /* TopicsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsRepository.swift; sourceTree = "<group>"; };
+		D028CCF52CB9619B00742620 /* Topic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic.swift; sourceTree = "<group>"; };
 		D04191772CA57A6F0034722A /* TopicsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsService.swift; sourceTree = "<group>"; };
-		D041917F2CA595400034722A /* Topic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic.swift; sourceTree = "<group>"; };
+		D041917F2CA595400034722A /* TopicResponseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicResponseItem.swift; sourceTree = "<group>"; };
 		D04191832CA5B0650034722A /* TopicsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsServiceTests.swift; sourceTree = "<group>"; };
 		D04191852CA6A5910034722A /* TopicsServiceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsServiceClient.swift; sourceTree = "<group>"; };
 		D046511C2C933FE600F47C66 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
@@ -1036,6 +1040,7 @@
 				5D3123832C85ADDF0088B931 /* ActivityRepository.swift */,
 				4E5ED2042C6E1F8700750BDA /* AppConfigRepository.swift */,
 				5D4E255C2C821C8E00FD9A28 /* CoreDataRepository.swift */,
+				D028CCF32CB4247100742620 /* TopicsRepository.swift */,
 				5D6295292C87429000BBB394 /* GOV.xcdatamodeld */,
 			);
 			path = Repositories;
@@ -1690,7 +1695,8 @@
 		D041917C2CA57B3D0034722A /* Topics */ = {
 			isa = PBXGroup;
 			children = (
-				D041917F2CA595400034722A /* Topic.swift */,
+				D028CCF52CB9619B00742620 /* Topic.swift */,
+				D041917F2CA595400034722A /* TopicResponseItem.swift */,
 			);
 			path = Topics;
 			sourceTree = "<group>";
@@ -2040,6 +2046,7 @@
 				D093BA672CB3CBEC004F489B /* EditTopicsCoordinator.swift in Sources */,
 				5D349F672C6B548200B7F747 /* RequestBuilder.swift in Sources */,
 				168F6FAA2C4FC56B00A0D7F7 /* WidgetViewModel.swift in Sources */,
+				D028CCF42CB4247100742620 /* TopicsRepository.swift in Sources */,
 				16F961A72C989165005CFB04 /* SearchResult.swift in Sources */,
 				5DBE080C2C4812ED00B58DBE /* BaseViewController.swift in Sources */,
 				5DBE080E2C49233200B58DBE /* OnboardingService.swift in Sources */,
@@ -2100,6 +2107,7 @@
 				D0C1F1E62CA4434100DD3D61 /* TopicsWidgetView.swift in Sources */,
 				5D925B212CB7FACA00A1E241 /* UITableView+Convenience.swift in Sources */,
 				5D0BD45B2C9B206F00220625 /* JSONDecoder+Extensions.swift in Sources */,
+				D028CCF62CB9619B00742620 /* Topic.swift in Sources */,
 				D0A8B3CA2CA1A38400849304 /* SignableDecoder.swift in Sources */,
 				5D4F97EB2BFF7725002CBDDE /* CoordinatorBuilder.swift in Sources */,
 				5D41DB5D2C0870020011E691 /* Container+Aliases.swift in Sources */,
@@ -2133,7 +2141,7 @@
 				5DB6AD312CA1B94400E92F4C /* DateFormatter+Convenience.swift in Sources */,
 				1666F4A02C86124900DBD064 /* SearchModalButton.swift in Sources */,
 				4E6663C52C736ABD0063E81C /* Feature.swift in Sources */,
-				D04191802CA595400034722A /* Topic.swift in Sources */,
+				D04191802CA595400034722A /* TopicResponseItem.swift in Sources */,
 				5DE597B72C2EF44F003613C8 /* Container+DataStores.swift in Sources */,
 				5D8683992C3431050024F2D8 /* ResolvedDeeplinkRoute.swift in Sources */,
 				5D08A9002C9AFABB0049D798 /* Result+Extensions.swift in Sources */,

--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		D028CCF82CB96ADB00742620 /* MockTopicsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF72CB96AD100742620 /* MockTopicsRepository.swift */; };
 		D028CCFA2CB9854F00742620 /* EditTopicsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF92CB9854F00742620 /* EditTopicsViewModelTests.swift */; };
 		D028CCFC2CB989E600742620 /* TopicsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCFB2CB989E600742620 /* TopicsRepositoryTests.swift */; };
+		D028CCFE2CBD24B300742620 /* Topics.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = D028CCFD2CBD24B300742620 /* Topics.xcstrings */; };
 		D04191782CA57A6F0034722A /* TopicsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191772CA57A6F0034722A /* TopicsService.swift */; };
 		D04191802CA595400034722A /* TopicResponseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D041917F2CA595400034722A /* TopicResponseItem.swift */; };
 		D04191842CA5B06D0034722A /* TopicsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191832CA5B0650034722A /* TopicsServiceTests.swift */; };
@@ -616,6 +617,7 @@
 		D028CCF72CB96AD100742620 /* MockTopicsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTopicsRepository.swift; sourceTree = "<group>"; };
 		D028CCF92CB9854F00742620 /* EditTopicsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsViewModelTests.swift; sourceTree = "<group>"; };
 		D028CCFB2CB989E600742620 /* TopicsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsRepositoryTests.swift; sourceTree = "<group>"; };
+		D028CCFD2CBD24B300742620 /* Topics.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Topics.xcstrings; sourceTree = "<group>"; };
 		D04191772CA57A6F0034722A /* TopicsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsService.swift; sourceTree = "<group>"; };
 		D041917F2CA595400034722A /* TopicResponseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicResponseItem.swift; sourceTree = "<group>"; };
 		D04191832CA5B0650034722A /* TopicsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsServiceTests.swift; sourceTree = "<group>"; };
@@ -1154,6 +1156,7 @@
 				5D742BDB2C99799000E7B87A /* Search.xcstrings */,
 				5D742BD92C99791A00E7B87A /* Settings.xcstrings */,
 				4E4FF25B2C9B67B500310AEC /* RecentActivity.xcstrings */,
+				D028CCFD2CBD24B300742620 /* Topics.xcstrings */,
 			);
 			path = Strings;
 			sourceTree = "<group>";
@@ -1909,6 +1912,7 @@
 				5D51D1602C245AAC008AC8E4 /* PrivacyInfo.xcprivacy in Resources */,
 				5D742BD82C9978B800E7B87A /* Home.xcstrings in Resources */,
 				D0A8B3C22C9DC66E00849304 /* integration_pubkey.der in Resources */,
+				D028CCFE2CBD24B300742620 /* Topics.xcstrings in Resources */,
 				D0A8B3C82CA18C2D00849304 /* MockAppConfigResponseInvalidSig.json in Resources */,
 				5D41DB7C2C09BF340011E691 /* Settings.bundle in Resources */,
 				4E003E7C2C75EE97008FCBF2 /* MockAppConfigResponseInvalid.json in Resources */,

--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -281,6 +281,8 @@
 		D028CCF42CB4247100742620 /* TopicsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF32CB4247100742620 /* TopicsRepository.swift */; };
 		D028CCF62CB9619B00742620 /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF52CB9619B00742620 /* Topic.swift */; };
 		D028CCF82CB96ADB00742620 /* MockTopicsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF72CB96AD100742620 /* MockTopicsRepository.swift */; };
+		D028CCFA2CB9854F00742620 /* EditTopicsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF92CB9854F00742620 /* EditTopicsViewModelTests.swift */; };
+		D028CCFC2CB989E600742620 /* TopicsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCFB2CB989E600742620 /* TopicsRepositoryTests.swift */; };
 		D04191782CA57A6F0034722A /* TopicsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191772CA57A6F0034722A /* TopicsService.swift */; };
 		D04191802CA595400034722A /* TopicResponseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D041917F2CA595400034722A /* TopicResponseItem.swift */; };
 		D04191842CA5B06D0034722A /* TopicsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191832CA5B0650034722A /* TopicsServiceTests.swift */; };
@@ -612,6 +614,8 @@
 		D028CCF32CB4247100742620 /* TopicsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsRepository.swift; sourceTree = "<group>"; };
 		D028CCF52CB9619B00742620 /* Topic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic.swift; sourceTree = "<group>"; };
 		D028CCF72CB96AD100742620 /* MockTopicsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTopicsRepository.swift; sourceTree = "<group>"; };
+		D028CCF92CB9854F00742620 /* EditTopicsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsViewModelTests.swift; sourceTree = "<group>"; };
+		D028CCFB2CB989E600742620 /* TopicsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsRepositoryTests.swift; sourceTree = "<group>"; };
 		D04191772CA57A6F0034722A /* TopicsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsService.swift; sourceTree = "<group>"; };
 		D041917F2CA595400034722A /* TopicResponseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicResponseItem.swift; sourceTree = "<group>"; };
 		D04191832CA5B0650034722A /* TopicsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsServiceTests.swift; sourceTree = "<group>"; };
@@ -694,6 +698,7 @@
 				5D5A25E62CAD44800013704A /* SearchItemTests.swift */,
 				D0F86E192CAC241400FF2D9E /* TopicTests.swift */,
 				D0B89D9C2CAD57B300AD93ED /* TopicsWidgetViewModelTests.swift */,
+				D028CCF92CB9854F00742620 /* EditTopicsViewModelTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1536,6 +1541,7 @@
 				5DE283522CAC4EBA00E95800 /* ActivityRepositoryTests.swift */,
 				4E18E0912C74DD5D00538CF0 /* AppConfigRepositoryTests.swift */,
 				5DC527B62C86FACA005E3158 /* CoreDataRepositoryTests.swift */,
+				D028CCFB2CB989E600742620 /* TopicsRepositoryTests.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -2194,6 +2200,7 @@
 				5DC79FA72CA170D600014446 /* SearchServiceTests.swift in Sources */,
 				D028CCF82CB96ADB00742620 /* MockTopicsRepository.swift in Sources */,
 				16ACCF762C6431B300017A11 /* SettingsViewModelTests.swift in Sources */,
+				D028CCFC2CB989E600742620 /* TopicsRepositoryTests.swift in Sources */,
 				5DB6AD342CA1C0EA00E92F4C /* Date+Arrangers.swift in Sources */,
 				5D37EA1A2C3E865F006B36CB /* TabCoordinatorTests.swift in Sources */,
 				D0F86E172CAC068B00FF2D9E /* MockTopicsService.swift in Sources */,
@@ -2251,6 +2258,7 @@
 				16F9619D2C8899D4005CFB04 /* SearchCoordinatorTests.swift in Sources */,
 				5D93EE832C36849B00D90C0C /* MockDeeplinkRoute.swift in Sources */,
 				5DE2834C2CAC484000E95800 /* ActivityServiceTests.swift in Sources */,
+				D028CCFA2CB9854F00742620 /* EditTopicsViewModelTests.swift in Sources */,
 				5D26A7632C92E0A5009902DD /* CrashlyticsClientTests.swift in Sources */,
 				3DEC85A82C89C5A40044D5F9 /* AnalyticsConsentCoordinatorTests.swift in Sources */,
 				3D9C93472CB01CDA00EFA337 /* MockAppVersionProvider.swift in Sources */,

--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 		D028CCFE2CBD24B300742620 /* Topics.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = D028CCFD2CBD24B300742620 /* Topics.xcstrings */; };
 		D028CD002CBD598E00742620 /* EditTopicsViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCFF2CBD597700742620 /* EditTopicsViewControllerSnapshotTests.swift */; };
 		D028CD012CBD5A2300742620 /* MockTopicsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF72CB96AD100742620 /* MockTopicsRepository.swift */; };
+		D028CD032CBD775000742620 /* EditTopicsCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CD022CBD775000742620 /* EditTopicsCoordinatorTests.swift */; };
 		D04191782CA57A6F0034722A /* TopicsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191772CA57A6F0034722A /* TopicsService.swift */; };
 		D04191802CA595400034722A /* TopicResponseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D041917F2CA595400034722A /* TopicResponseItem.swift */; };
 		D04191842CA5B06D0034722A /* TopicsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191832CA5B0650034722A /* TopicsServiceTests.swift */; };
@@ -621,6 +622,7 @@
 		D028CCFB2CB989E600742620 /* TopicsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsRepositoryTests.swift; sourceTree = "<group>"; };
 		D028CCFD2CBD24B300742620 /* Topics.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Topics.xcstrings; sourceTree = "<group>"; };
 		D028CCFF2CBD597700742620 /* EditTopicsViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
+		D028CD022CBD775000742620 /* EditTopicsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsCoordinatorTests.swift; sourceTree = "<group>"; };
 		D04191772CA57A6F0034722A /* TopicsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsService.swift; sourceTree = "<group>"; };
 		D041917F2CA595400034722A /* TopicResponseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicResponseItem.swift; sourceTree = "<group>"; };
 		D04191832CA5B0650034722A /* TopicsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsServiceTests.swift; sourceTree = "<group>"; };
@@ -967,6 +969,7 @@
 				5D37EA052C3E865F006B36CB /* TabCoordinatorTests.swift */,
 				4E46704A2C9B19FB0017DA2E /* RecentActivityCoordinatorTests.swift */,
 				D0B89D9E2CAD60B700AD93ED /* TopicsCoordinatorTests.swift */,
+				D028CD022CBD775000742620 /* EditTopicsCoordinatorTests.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -2280,6 +2283,7 @@
 				5DE283512CAC492B00E95800 /* MockActivityRepository.swift in Sources */,
 				5D37EA0D2C3E865F006B36CB /* DeeplinkDataStoreTests.swift in Sources */,
 				1651C6E92C63D4D300864C5C /* HomeViewModelTests.swift in Sources */,
+				D028CD032CBD775000742620 /* EditTopicsCoordinatorTests.swift in Sources */,
 				5D37EA1B2C3E865F006B36CB /* AnimationViewTests.swift in Sources */,
 				5D349C982C36995500161317 /* XCTestExpectation+Extensions.swift in Sources */,
 				5DCDA1012CA20C7D00A6DF90 /* MonthGroupKeyTests.swift in Sources */,

--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -288,6 +288,9 @@
 		D05AF4DC2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05AF4DB2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift */; };
 		D06EB96C2CA6F71E007EA081 /* TopicCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06EB96B2CA6F71E007EA081 /* TopicCard.swift */; };
 		D093BA612CAF02D4004F489B /* Bundle+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DBE71AF2CAE8371004ABB5E /* Bundle+Tests.swift */; };
+		D093BA632CB0499A004F489B /* EditTopicsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093BA622CB0499A004F489B /* EditTopicsView.swift */; };
+		D093BA652CB04C68004F489B /* EditTopicsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093BA642CB04C68004F489B /* EditTopicsViewModel.swift */; };
+		D093BA672CB3CBEC004F489B /* EditTopicsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093BA662CB3CBEC004F489B /* EditTopicsCoordinator.swift */; };
 		D0A8B3C22C9DC66E00849304 /* integration_pubkey.der in Resources */ = {isa = PBXBuildFile; fileRef = D0A8B3C12C9DC66E00849304 /* integration_pubkey.der */; };
 		D0A8B3C42C9DD01200849304 /* Codable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A8B3C32C9DD01200849304 /* Codable+Extensions.swift */; };
 		D0A8B3C62CA16D8C00849304 /* SignableDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A8B3C52CA16D8C00849304 /* SignableDecoderTests.swift */; };
@@ -612,6 +615,9 @@
 		D05AF4D92CAD3C2900F86DD0 /* TopicDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicDetailView.swift; sourceTree = "<group>"; };
 		D05AF4DB2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsWidgetViewModel.swift; sourceTree = "<group>"; };
 		D06EB96B2CA6F71E007EA081 /* TopicCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicCard.swift; sourceTree = "<group>"; };
+		D093BA622CB0499A004F489B /* EditTopicsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsView.swift; sourceTree = "<group>"; };
+		D093BA642CB04C68004F489B /* EditTopicsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsViewModel.swift; sourceTree = "<group>"; };
+		D093BA662CB3CBEC004F489B /* EditTopicsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsCoordinator.swift; sourceTree = "<group>"; };
 		D0A8B3C12C9DC66E00849304 /* integration_pubkey.der */ = {isa = PBXFileReference; lastKnownFileType = file; path = integration_pubkey.der; sourceTree = "<group>"; };
 		D0A8B3C32C9DD01200849304 /* Codable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Codable+Extensions.swift"; sourceTree = "<group>"; };
 		D0A8B3C52CA16D8C00849304 /* SignableDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignableDecoderTests.swift; sourceTree = "<group>"; };
@@ -1242,6 +1248,7 @@
 				16EE1A442C6F8ED3005E820F /* SearchCoordinator.swift */,
 				1679D5742C3F5E6900AA2EB0 /* SettingsCoordinator.swift */,
 				5D962D5D2C29BD0B0038BC0A /* TabCoordinator.swift */,
+				D093BA662CB3CBEC004F489B /* EditTopicsCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -1693,6 +1700,7 @@
 			children = (
 				D05AF4DB2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift */,
 				D0C1F1E32CA440F200DD3D61 /* TopicCardModel.swift */,
+				D093BA642CB04C68004F489B /* EditTopicsViewModel.swift */,
 			);
 			path = Topics;
 			sourceTree = "<group>";
@@ -1719,6 +1727,7 @@
 			isa = PBXGroup;
 			children = (
 				D05AF4D92CAD3C2900F86DD0 /* TopicDetailView.swift */,
+				D093BA622CB0499A004F489B /* EditTopicsView.swift */,
 			);
 			path = Topics;
 			sourceTree = "<group>";
@@ -2028,6 +2037,7 @@
 				D0C1F1E42CA440F200DD3D61 /* TopicCardModel.swift in Sources */,
 				16EE1A432C6F89D9005E820F /* SearchViewModel.swift in Sources */,
 				163800FF2C99DAF900C3DDD1 /* ListInformationView.swift in Sources */,
+				D093BA672CB3CBEC004F489B /* EditTopicsCoordinator.swift in Sources */,
 				5D349F672C6B548200B7F747 /* RequestBuilder.swift in Sources */,
 				168F6FAA2C4FC56B00A0D7F7 /* WidgetViewModel.swift in Sources */,
 				16F961A72C989165005CFB04 /* SearchResult.swift in Sources */,
@@ -2063,6 +2073,7 @@
 				5DF8854B2CAC181D0060A40D /* NSFetchedResultsController+Extensions.swift in Sources */,
 				5DBE08072C480CA700B58DBE /* UINavigationController+Convenience.swift in Sources */,
 				5DD09EC82C9ADB8500494550 /* SearchService.swift in Sources */,
+				D093BA632CB0499A004F489B /* EditTopicsView.swift in Sources */,
 				D05AF4DC2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift in Sources */,
 				5D79AEC02C32B9180061F344 /* AnimationView.swift in Sources */,
 				5D9E67C82C5A2E1700DB7877 /* DividerView.swift in Sources */,
@@ -2127,6 +2138,7 @@
 				5D8683992C3431050024F2D8 /* ResolvedDeeplinkRoute.swift in Sources */,
 				5D08A9002C9AFABB0049D798 /* Result+Extensions.swift in Sources */,
 				5DE597B62C2EF422003613C8 /* APIServiceClient.swift in Sources */,
+				D093BA652CB04C68004F489B /* EditTopicsViewModel.swift in Sources */,
 				D0A8B3C42C9DD01200849304 /* Codable+Extensions.swift in Sources */,
 				5DE74DE32CB538E9000B43B5 /* RecentActivityListViewController.swift in Sources */,
 				5D3123842C85ADDF0088B931 /* ActivityRepository.swift in Sources */,

--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -280,6 +280,7 @@
 		96DE82882C7E25ED0071D792 /* SinglePixelLineHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DE82872C7E25ED0071D792 /* SinglePixelLineHelper.swift */; };
 		D028CCF42CB4247100742620 /* TopicsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF32CB4247100742620 /* TopicsRepository.swift */; };
 		D028CCF62CB9619B00742620 /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF52CB9619B00742620 /* Topic.swift */; };
+		D028CCF82CB96ADB00742620 /* MockTopicsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF72CB96AD100742620 /* MockTopicsRepository.swift */; };
 		D04191782CA57A6F0034722A /* TopicsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191772CA57A6F0034722A /* TopicsService.swift */; };
 		D04191802CA595400034722A /* TopicResponseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D041917F2CA595400034722A /* TopicResponseItem.swift */; };
 		D04191842CA5B06D0034722A /* TopicsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191832CA5B0650034722A /* TopicsServiceTests.swift */; };
@@ -610,6 +611,7 @@
 		96DE82872C7E25ED0071D792 /* SinglePixelLineHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglePixelLineHelper.swift; sourceTree = "<group>"; };
 		D028CCF32CB4247100742620 /* TopicsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsRepository.swift; sourceTree = "<group>"; };
 		D028CCF52CB9619B00742620 /* Topic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic.swift; sourceTree = "<group>"; };
+		D028CCF72CB96AD100742620 /* MockTopicsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTopicsRepository.swift; sourceTree = "<group>"; };
 		D04191772CA57A6F0034722A /* TopicsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsService.swift; sourceTree = "<group>"; };
 		D041917F2CA595400034722A /* TopicResponseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicResponseItem.swift; sourceTree = "<group>"; };
 		D04191832CA5B0650034722A /* TopicsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsServiceTests.swift; sourceTree = "<group>"; };
@@ -744,6 +746,7 @@
 		4E18E08E2C74A43A00538CF0 /* Repositories */ = {
 			isa = PBXGroup;
 			children = (
+				D028CCF72CB96AD100742620 /* MockTopicsRepository.swift */,
 				4E18E08F2C74A45500538CF0 /* MockAppConfigRepository.swift */,
 				5DE283502CAC492B00E95800 /* MockActivityRepository.swift */,
 			);
@@ -2189,6 +2192,7 @@
 				5DC527B72C86FACA005E3158 /* CoreDataRepositoryTests.swift in Sources */,
 				D0F86E132CAAFF0C00FF2D9E /* TopicsServiceClientTests.swift in Sources */,
 				5DC79FA72CA170D600014446 /* SearchServiceTests.swift in Sources */,
+				D028CCF82CB96ADB00742620 /* MockTopicsRepository.swift in Sources */,
 				16ACCF762C6431B300017A11 /* SettingsViewModelTests.swift in Sources */,
 				5DB6AD342CA1C0EA00E92F4C /* Date+Arrangers.swift in Sources */,
 				5D37EA1A2C3E865F006B36CB /* TabCoordinatorTests.swift in Sources */,

--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -284,6 +284,8 @@
 		D028CCFA2CB9854F00742620 /* EditTopicsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF92CB9854F00742620 /* EditTopicsViewModelTests.swift */; };
 		D028CCFC2CB989E600742620 /* TopicsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCFB2CB989E600742620 /* TopicsRepositoryTests.swift */; };
 		D028CCFE2CBD24B300742620 /* Topics.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = D028CCFD2CBD24B300742620 /* Topics.xcstrings */; };
+		D028CD002CBD598E00742620 /* EditTopicsViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCFF2CBD597700742620 /* EditTopicsViewControllerSnapshotTests.swift */; };
+		D028CD012CBD5A2300742620 /* MockTopicsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D028CCF72CB96AD100742620 /* MockTopicsRepository.swift */; };
 		D04191782CA57A6F0034722A /* TopicsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191772CA57A6F0034722A /* TopicsService.swift */; };
 		D04191802CA595400034722A /* TopicResponseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D041917F2CA595400034722A /* TopicResponseItem.swift */; };
 		D04191842CA5B06D0034722A /* TopicsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191832CA5B0650034722A /* TopicsServiceTests.swift */; };
@@ -618,6 +620,7 @@
 		D028CCF92CB9854F00742620 /* EditTopicsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsViewModelTests.swift; sourceTree = "<group>"; };
 		D028CCFB2CB989E600742620 /* TopicsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsRepositoryTests.swift; sourceTree = "<group>"; };
 		D028CCFD2CBD24B300742620 /* Topics.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Topics.xcstrings; sourceTree = "<group>"; };
+		D028CCFF2CBD597700742620 /* EditTopicsViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		D04191772CA57A6F0034722A /* TopicsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsService.swift; sourceTree = "<group>"; };
 		D041917F2CA595400034722A /* TopicResponseItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicResponseItem.swift; sourceTree = "<group>"; };
 		D04191832CA5B0650034722A /* TopicsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsServiceTests.swift; sourceTree = "<group>"; };
@@ -1205,6 +1208,7 @@
 		5D8922702C071FF60019FBD7 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				D028CCFF2CBD597700742620 /* EditTopicsViewControllerSnapshotTests.swift */,
 				3DEC85A32C89BCE90044D5F9 /* AnalyticsConsentViewControllerSnapshotTests.swift */,
 				3D9C93412CB017E900EFA337 /* AppForcedUpdateViewControllerSnapshotTests.swift */,
 				3D15E7B92CB576330046CE64 /* AppRecommendUpdateViewControllerSnapshotTests.swift */,
@@ -2003,6 +2007,7 @@
 				4EDBBEAD2C9C0CAF00F31577 /* CoreDataRepository+Arrangers.swift in Sources */,
 				5D0BD45F2C9B244A00220625 /* MockSearchService.swift in Sources */,
 				5DC069F22C3C196B00A81AAE /* MockAccessibilityManager.swift in Sources */,
+				D028CD012CBD5A2300742620 /* MockTopicsRepository.swift in Sources */,
 				5D4F6D402CA4181D006D0B5B /* MockAppConfigService.swift in Sources */,
 				3D15E7BA2CB576330046CE64 /* AppRecommendUpdateViewControllerSnapshotTests.swift in Sources */,
 				5D014FEB2CB96ABB005D32C8 /* RecentActivityListViewControllerSnapshotTests.swift in Sources */,
@@ -2011,6 +2016,7 @@
 				5D41DB552C0862840011E691 /* LaunchViewControllerSnapshotTests.swift in Sources */,
 				3D9C93462CB01CDA00EFA337 /* MockAppVersionProvider.swift in Sources */,
 				5DE2BBBD2C982824003116B6 /* MockURLOpener.swift in Sources */,
+				D028CD002CBD598E00742620 /* EditTopicsViewControllerSnapshotTests.swift in Sources */,
 				5DF8854E2CAC1A120060A40D /* MockActivityService.swift in Sources */,
 				5D014FEC2CB96CC7005D32C8 /* ActivityItem+Arrangers.swift in Sources */,
 				168F6FAC2C4FFF9500A0D7F7 /* HomeViewControllerSnapshotTests.swift in Sources */,

--- a/Production/govuk_ios/Builders/CoordinatorBuilder.swift
+++ b/Production/govuk_ios/Builders/CoordinatorBuilder.swift
@@ -137,12 +137,13 @@ class CoordinatorBuilder {
     func editTopics(_ topics: [Topic],
                     navigationController: UINavigationController,
                     didDismissAction: @escaping () -> Void) -> BaseCoordinator {
-        EditTopicsCoordinator(navigationController: navigationController,
-                              analyticsService: container.analyticsService.resolve(),
-                              topicsService: container.topicsService.resolve(),
-                              viewControllerBuilder: ViewControllerBuilder(),
-                              topics: topics,
-                              dismissed: didDismissAction
+        EditTopicsCoordinator(
+            navigationController: navigationController,
+            analyticsService: container.analyticsService.resolve(),
+            topicsService: container.topicsService.resolve(),
+            viewControllerBuilder: ViewControllerBuilder(),
+            topics: topics,
+            dismissed: didDismissAction
         )
     }
 }

--- a/Production/govuk_ios/Builders/CoordinatorBuilder.swift
+++ b/Production/govuk_ios/Builders/CoordinatorBuilder.swift
@@ -139,6 +139,7 @@ class CoordinatorBuilder {
                     didDismissAction: @escaping () -> Void) -> BaseCoordinator {
         EditTopicsCoordinator(navigationController: navigationControlloer,
                               analyticsService: container.analyticsService.resolve(),
+                              topicsService: container.topicsService.resolve(),
                               viewControllerBuilder: ViewControllerBuilder(),
                               topics: topics,
                               dismissed: didDismissAction

--- a/Production/govuk_ios/Builders/CoordinatorBuilder.swift
+++ b/Production/govuk_ios/Builders/CoordinatorBuilder.swift
@@ -135,9 +135,9 @@ class CoordinatorBuilder {
     }
 
     func editTopics(_ topics: [Topic],
-                    navigationControlloer: UINavigationController,
+                    navigationController: UINavigationController,
                     didDismissAction: @escaping () -> Void) -> BaseCoordinator {
-        EditTopicsCoordinator(navigationController: navigationControlloer,
+        EditTopicsCoordinator(navigationController: navigationController,
                               analyticsService: container.analyticsService.resolve(),
                               topicsService: container.topicsService.resolve(),
                               viewControllerBuilder: ViewControllerBuilder(),

--- a/Production/govuk_ios/Builders/CoordinatorBuilder.swift
+++ b/Production/govuk_ios/Builders/CoordinatorBuilder.swift
@@ -133,4 +133,15 @@ class CoordinatorBuilder {
             topic: topic
         )
     }
+
+    func editTopics(_ topics: [Topic],
+                    navigationControlloer: UINavigationController,
+                    didDismissAction: @escaping () -> Void) -> BaseCoordinator {
+        EditTopicsCoordinator(navigationController: navigationControlloer,
+                              analyticsService: container.analyticsService.resolve(),
+                              viewControllerBuilder: ViewControllerBuilder(),
+                              topics: topics,
+                              dismissed: didDismissAction
+        )
+    }
 }

--- a/Production/govuk_ios/Builders/ViewControllerBuilder.swift
+++ b/Production/govuk_ios/Builders/ViewControllerBuilder.swift
@@ -104,7 +104,7 @@ class ViewControllerBuilder {
     }
 
     @MainActor
-    func topicDetail(topic: Topic?,
+    func topicDetail(topic: Topic,
                      analyticsService: AnalyticsServiceInterface
     ) -> UIViewController {
         var view = TopicDetailView()

--- a/Production/govuk_ios/Builders/ViewControllerBuilder.swift
+++ b/Production/govuk_ios/Builders/ViewControllerBuilder.swift
@@ -115,8 +115,10 @@ class ViewControllerBuilder {
     @MainActor
     func editTopics(_ topics: [Topic],
                     analyicsService: AnalyticsServiceInterface,
+                    topicsService: TopicsServiceInterface,
                     dismissAction: @escaping () -> Void) -> UIViewController {
         let viewModel = EditTopicsViewModel(topics: topics,
+                                            topicsService: topicsService,
                                             dismissAction: dismissAction)
         let view = EditTopicsView(
             viewModel: viewModel

--- a/Production/govuk_ios/Builders/ViewControllerBuilder.swift
+++ b/Production/govuk_ios/Builders/ViewControllerBuilder.swift
@@ -114,11 +114,12 @@ class ViewControllerBuilder {
 
     @MainActor
     func editTopics(_ topics: [Topic],
-                    analyicsService: AnalyticsServiceInterface,
+                    analyticsService: AnalyticsServiceInterface,
                     topicsService: TopicsServiceInterface,
                     dismissAction: @escaping () -> Void) -> UIViewController {
         let viewModel = EditTopicsViewModel(topics: topics,
                                             topicsService: topicsService,
+                                            analyticsService: analyticsService,
                                             dismissAction: dismissAction)
         let view = EditTopicsView(
             viewModel: viewModel

--- a/Production/govuk_ios/Builders/ViewControllerBuilder.swift
+++ b/Production/govuk_ios/Builders/ViewControllerBuilder.swift
@@ -49,15 +49,13 @@ class ViewControllerBuilder {
     @MainActor
     func home(searchButtonPrimaryAction: @escaping () -> Void,
               configService: AppConfigServiceInterface,
-              topicsService: TopicsServiceInterface,
               recentActivityAction: @escaping () -> Void,
-              topicAction: @escaping (Topic) -> Void) -> UIViewController {
+              topicWidgetViewModel: TopicsWidgetViewModel) -> UIViewController {
         let viewModel = HomeViewModel(
             configService: configService,
-            topicsService: topicsService,
             searchButtonPrimaryAction: searchButtonPrimaryAction,
             recentActivityAction: recentActivityAction,
-            topicAction: topicAction
+            topicWidgetViewModel: topicWidgetViewModel
         )
         return HomeViewController(
             viewModel: viewModel
@@ -106,11 +104,23 @@ class ViewControllerBuilder {
     }
 
     @MainActor
-    func topicDetail(topic: Topic,
+    func topicDetail(topic: Topic?,
                      analyticsService: AnalyticsServiceInterface
     ) -> UIViewController {
         var view = TopicDetailView()
         view.topic = topic
+        return HostingViewController(rootView: view)
+    }
+
+    @MainActor
+    func editTopics(_ topics: [Topic],
+                    analyicsService: AnalyticsServiceInterface,
+                    dismissAction: @escaping () -> Void) -> UIViewController {
+        let viewModel = EditTopicsViewModel(topics: topics,
+                                            dismissAction: dismissAction)
+        let view = EditTopicsView(
+            viewModel: viewModel
+        )
         return HostingViewController(rootView: view)
     }
 }

--- a/Production/govuk_ios/Builders/ViewControllerBuilder.swift
+++ b/Production/govuk_ios/Builders/ViewControllerBuilder.swift
@@ -117,10 +117,13 @@ class ViewControllerBuilder {
                     analyticsService: AnalyticsServiceInterface,
                     topicsService: TopicsServiceInterface,
                     dismissAction: @escaping () -> Void) -> UIViewController {
-        let viewModel = EditTopicsViewModel(topics: topics,
-                                            topicsService: topicsService,
-                                            analyticsService: analyticsService,
-                                            dismissAction: dismissAction)
+        let viewModel = EditTopicsViewModel(
+            topics: topics,
+            topicsService: topicsService,
+            analyticsService: analyticsService,
+            dismissAction: dismissAction
+        )
+
         let view = EditTopicsView(
             viewModel: viewModel
         )

--- a/Production/govuk_ios/Coordinators/EditTopicsCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/EditTopicsCoordinator.swift
@@ -2,16 +2,19 @@ import UIKit
 
 final class EditTopicsCoordinator: BaseCoordinator {
     private let analyticsService: AnalyticsServiceInterface
+    private let topicsService: TopicsServiceInterface
     private let viewControllerBuilder: ViewControllerBuilder
     private let topics: [Topic]
     private let dismissed: () -> Void
 
     init(navigationController: UINavigationController,
          analyticsService: AnalyticsServiceInterface,
+         topicsService: TopicsServiceInterface,
          viewControllerBuilder: ViewControllerBuilder,
          topics: [Topic],
          dismissed: @escaping () -> Void) {
         self.analyticsService = analyticsService
+        self.topicsService = topicsService
         self.viewControllerBuilder = viewControllerBuilder
         self.topics = topics
         self.dismissed = dismissed
@@ -22,6 +25,7 @@ final class EditTopicsCoordinator: BaseCoordinator {
         let viewController = viewControllerBuilder.editTopics(
             topics,
             analyicsService: analyticsService,
+            topicsService: topicsService,
             dismissAction: { [weak self] in
                 self?.dismissModal()
             }

--- a/Production/govuk_ios/Coordinators/EditTopicsCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/EditTopicsCoordinator.swift
@@ -1,0 +1,45 @@
+import UIKit
+
+final class EditTopicsCoordinator: BaseCoordinator {
+    private let analyticsService: AnalyticsServiceInterface
+    private let viewControllerBuilder: ViewControllerBuilder
+    private let topics: [Topic]
+    private let dismissed: () -> Void
+
+    init(navigationController: UINavigationController,
+         analyticsService: AnalyticsServiceInterface,
+         viewControllerBuilder: ViewControllerBuilder,
+         topics: [Topic],
+         dismissed: @escaping () -> Void) {
+        self.analyticsService = analyticsService
+        self.viewControllerBuilder = viewControllerBuilder
+        self.topics = topics
+        self.dismissed = dismissed
+        super.init(navigationController: navigationController)
+    }
+
+    override func start(url: URL?) {
+        let viewController = viewControllerBuilder.editTopics(
+            topics,
+            analyicsService: analyticsService,
+            dismissAction: { [weak self] in
+                self?.dismissModal()
+            }
+        )
+        set(viewController, animated: true)
+    }
+
+    private func dismissModal() {
+        root.dismiss(
+            animated: true,
+            completion: { [weak self] in
+                self?.dismissed()
+            }
+        )
+    }
+
+    override func finish() {
+        super.finish()
+        dismissed()
+    }
+}

--- a/Production/govuk_ios/Coordinators/EditTopicsCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/EditTopicsCoordinator.swift
@@ -24,7 +24,7 @@ final class EditTopicsCoordinator: BaseCoordinator {
     override func start(url: URL?) {
         let viewController = viewControllerBuilder.editTopics(
             topics,
-            analyicsService: analyticsService,
+            analyticsService: analyticsService,
             topicsService: topicsService,
             dismissAction: { [weak self] in
                 self?.dismissModal()

--- a/Production/govuk_ios/Coordinators/HomeCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/HomeCoordinator.swift
@@ -29,9 +29,8 @@ class HomeCoordinator: TabItemCoordinator {
         let viewController = viewControllerBuilder.home(
             searchButtonPrimaryAction: searchActionButtonPressed,
             configService: configService,
-            topicsService: topicsService,
             recentActivityAction: recentActivityCoordinator,
-            topicAction: topicAction
+            topicWidgetViewModel: topicWidgetViewModel
         )
         set([viewController], animated: false)
     }
@@ -67,6 +66,13 @@ class HomeCoordinator: TabItemCoordinator {
         }
     }
 
+    private var topicWidgetViewModel: TopicsWidgetViewModel {
+        let viewModel = TopicsWidgetViewModel(topicsService: topicsService,
+                                              topicAction: topicAction,
+                                              editAction: editTopicsAction)
+        return viewModel
+    }
+
     private var topicAction: (Topic) -> Void {
         return { [weak self] topic in
             guard let self = self else { return }
@@ -75,6 +81,21 @@ class HomeCoordinator: TabItemCoordinator {
                 navigationController: self.root
             )
             start(coordinator)
+        }
+    }
+
+    private var editTopicsAction: ([Topic]) -> Void {
+        return { [weak self] topics in
+            guard let self = self else { return }
+            let navigationController = UINavigationController()
+            let coordinator = self.coordinatorBuilder.editTopics(
+                topics,
+                navigationControlloer: navigationController,
+                didDismissAction: {
+                    self.root.viewWillReAppear()
+                }
+            )
+            self.present(coordinator)
         }
     }
 }

--- a/Production/govuk_ios/Coordinators/HomeCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/HomeCoordinator.swift
@@ -90,7 +90,7 @@ class HomeCoordinator: TabItemCoordinator {
             let navigationController = UINavigationController()
             let coordinator = self.coordinatorBuilder.editTopics(
                 topics,
-                navigationControlloer: navigationController,
+                navigationController: navigationController,
                 didDismissAction: {
                     self.root.viewWillReAppear()
                 }

--- a/Production/govuk_ios/Extensions/Analytics/AppEvent+Convenience.swift
+++ b/Production/govuk_ios/Extensions/Analytics/AppEvent+Convenience.swift
@@ -111,4 +111,16 @@ extension AppEvent {
             ]
         )
     }
+
+    static func toggleTopic(title: String,
+                            isFavorite: Bool) -> AppEvent {
+        .init(name: "Function",
+              params: [
+                "text": title,
+                "type": "toggle",
+                "section": "Topics",
+                "action": isFavorite ? "On" : "Off"
+              ]
+        )
+    }
 }

--- a/Production/govuk_ios/Extensions/Container/Container+DataStores.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+DataStores.swift
@@ -9,5 +9,6 @@ extension Container {
                 notificationCenter: .default
             ).load()
         }
+        .scope(.singleton)
     }
 }

--- a/Production/govuk_ios/Extensions/Container/Container+Repositories.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+Repositories.swift
@@ -15,4 +15,10 @@ extension Container {
             AppConfigRepository()
         }
     }
+
+    var topicsRespository: Factory<TopicsRepositoryInterface> {
+        Factory(self) {
+            TopicsRepository(coreData: self.coreDataRepository())
+        }
+    }
 }

--- a/Production/govuk_ios/Extensions/Container/Container+Repositories.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+Repositories.swift
@@ -16,7 +16,7 @@ extension Container {
         }
     }
 
-    var topicsRespository: Factory<TopicsRepositoryInterface> {
+    var topicsRepository: Factory<TopicsRepositoryInterface> {
         Factory(self) {
             TopicsRepository(coreData: self.coreDataRepository())
         }

--- a/Production/govuk_ios/Extensions/Container/Container+Services.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+Services.swift
@@ -73,7 +73,8 @@ extension Container {
     var topicsService: Factory<TopicsServiceInterface> {
         Factory(self) {
             TopicsService(
-                topicsServiceClient: self.topicsServiceClient()
+                topicsServiceClient: self.topicsServiceClient(),
+                topicsRepository: self.topicsRespository()
             )
         }
     }

--- a/Production/govuk_ios/Extensions/Container/Container+Services.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+Services.swift
@@ -74,7 +74,7 @@ extension Container {
         Factory(self) {
             TopicsService(
                 topicsServiceClient: self.topicsServiceClient(),
-                topicsRepository: self.topicsRespository()
+                topicsRepository: self.topicsRepository()
             )
         }
     }

--- a/Production/govuk_ios/Extensions/Foundation/String+Extensions.swift
+++ b/Production/govuk_ios/Extensions/Foundation/String+Extensions.swift
@@ -49,6 +49,13 @@ extension String {
             bundle: .main
         )
     }
+
+    static var topics: LocalStringBuilder {
+        .init(
+            tableName: "Topics",
+            bundle: .main
+        )
+    }
 }
 
 extension String {

--- a/Production/govuk_ios/Model/Topics/Topic.swift
+++ b/Production/govuk_ios/Model/Topics/Topic.swift
@@ -1,8 +1,23 @@
 import Foundation
+import CoreData
 
-struct Topic: Decodable {
-    let ref: String
-    let title: String
+@objc(Topic)
+class Topic: NSManagedObject,
+             Identifiable {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Topic> {
+        let request = NSFetchRequest<Topic>(entityName: "Topic")
+        request.sortDescriptors = [
+            NSSortDescriptor(
+                keyPath: \Topic.title,
+                ascending: true
+            )
+        ]
+        return request
+    }
+
+    @NSManaged public var ref: String
+    @NSManaged public var title: String
+    @NSManaged public var isFavorite: Bool
 
     var iconName: String {
         switch self.ref {

--- a/Production/govuk_ios/Model/Topics/TopicResponseItem.swift
+++ b/Production/govuk_ios/Model/Topics/TopicResponseItem.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct TopicResponseItem: Decodable {
+    let ref: String
+    let title: String
+}

--- a/Production/govuk_ios/Repositories/GOV.xcdatamodeld/GOV.xcdatamodel/contents
+++ b/Production/govuk_ios/Repositories/GOV.xcdatamodeld/GOV.xcdatamodel/contents
@@ -11,4 +11,9 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
+    <entity name="Topic" representedClassName="Topic" syncable="YES">
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="ref" attributeType="String"/>
+        <attribute name="title" attributeType="String"/>
+    </entity>
 </model>

--- a/Production/govuk_ios/Repositories/TopicsRepository.swift
+++ b/Production/govuk_ios/Repositories/TopicsRepository.swift
@@ -1,0 +1,88 @@
+import Foundation
+import CoreData
+
+protocol TopicsRepositoryInterface {
+    func saveTopicsList(_ topicResponses: [TopicResponseItem])
+    func fetchFavoriteTopics() -> [Topic]
+    func fetchAllTopics() -> [Topic]
+    func saveChanges()
+}
+
+struct TopicsRepository: TopicsRepositoryInterface {
+    private let coreData: CoreDataRepositoryInterface
+
+    init(coreData: CoreDataRepositoryInterface) {
+        self.coreData = coreData
+    }
+
+    func saveTopicsList(_ topicResponses: [TopicResponseItem]) {
+        let context = coreData.backgroundContext
+        let isFirstLaunch = fetchAllTopics().count == 0
+        topicResponses.forEach { topicResponse in
+            if !topicExists(for: topicResponse,
+                            in: context) {
+                createTopic(for: topicResponse,
+                            in: context,
+                            isFavorite: isFirstLaunch)
+            }
+        }
+        try? context.save()
+    }
+
+    func saveChanges() {
+        try? coreData.viewContext.save()
+    }
+
+    func fetchFavoriteTopics() -> [Topic] {
+        fetch(
+            predicate: .init(format: "isFavorite = true"),
+            context: coreData.viewContext
+        ).fetchedObjects ?? []
+    }
+
+    func fetchAllTopics() -> [Topic] {
+        fetch(
+            predicate: nil,
+            context: coreData.viewContext
+        ).fetchedObjects ?? []
+    }
+
+    private func fetchTopic(ref: String,
+                            context: NSManagedObjectContext
+    ) -> Topic? {
+        fetch(
+            predicate: .init(format: "ref = %@", ref),
+            context: coreData.backgroundContext
+        ).fetchedObjects?.first
+    }
+
+    private func topicExists(for topicResponse: TopicResponseItem,
+                             in context: NSManagedObjectContext) -> Bool {
+        fetchTopic(
+            ref: topicResponse.ref,
+            context: context
+        ) != nil
+    }
+
+    private func createTopic(for topicResponse: TopicResponseItem,
+                             in context: NSManagedObjectContext,
+                             isFavorite: Bool) {
+        let topic = Topic(context: context)
+        topic.ref = topicResponse.ref
+        topic.title = topicResponse.title
+        topic.isFavorite = isFavorite
+    }
+
+    private func fetch(predicate: NSPredicate?,
+                       context: NSManagedObjectContext?) -> NSFetchedResultsController<Topic> {
+        let fetchContext = context ?? coreData.viewContext
+        let request = Topic.fetchRequest()
+        request.predicate = predicate
+        return NSFetchedResultsController(
+            fetchRequest: request,
+            managedObjectContext: fetchContext,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        ).fetch()
+    }
+}

--- a/Production/govuk_ios/Resources/Strings/Common.xcstrings
+++ b/Production/govuk_ios/Resources/Strings/Common.xcstrings
@@ -12,6 +12,17 @@
         }
       }
     },
+    "editButtonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit"
+          }
+        }
+      }
+    },
     "openWebLinkHint" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Production/govuk_ios/Resources/Strings/Topics.xcstrings
+++ b/Production/govuk_ios/Resources/Strings/Topics.xcstrings
@@ -1,0 +1,39 @@
+{
+  "sourceLanguage" : "en-GB",
+  "strings" : {
+    "doneButtonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        }
+      }
+    },
+    "editTopicsSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Topics you select will be shown on the app home page so you can find them more easily"
+          }
+        }
+      }
+    },
+    "editTopicsTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit your topics"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Production/govuk_ios/ServiceClients/TopicsServiceClient.swift
+++ b/Production/govuk_ios/ServiceClients/TopicsServiceClient.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-typealias FetchTopicsListResult = (Result<[Topic], TopicsListError>) -> Void
+typealias FetchTopicsListResult = (Result<[TopicResponseItem], TopicsListError>) -> Void
 
 protocol TopicsServiceClientInterface {
     func fetchTopicsList(completion: @escaping FetchTopicsListResult)
@@ -33,7 +33,7 @@ struct TopicsServiceClient: TopicsServiceClientInterface {
                 switch result {
                 case .success(let data):
                     do {
-                        let topics = try JSONDecoder().decode([Topic].self, from: data)
+                        let topics = try JSONDecoder().decode([TopicResponseItem].self, from: data)
                         completion(.success(topics))
                     } catch {
                         completion(.failure(.decodingError))

--- a/Production/govuk_ios/Services/TopicsService.swift
+++ b/Production/govuk_ios/Services/TopicsService.swift
@@ -1,29 +1,45 @@
 import Foundation
 
 protocol TopicsServiceInterface {
-    func fetchTopics(completion: @escaping FetchTopicsListResult)
+    func downloadTopicsList(completion: @escaping FetchTopicsListResult)
+    func fetchAllTopics() -> [Topic]
+    func fetchFavoriteTopics() -> [Topic]
+    func updateFavoriteTopics()
 }
 
 struct TopicsService: TopicsServiceInterface {
     private let topicsServiceClient: TopicsServiceClientInterface
+    private let topicsRepository: TopicsRepositoryInterface
 
-    init(topicsServiceClient: TopicsServiceClientInterface) {
+    init(topicsServiceClient: TopicsServiceClientInterface,
+         topicsRepository: TopicsRepositoryInterface) {
         self.topicsServiceClient = topicsServiceClient
+        self.topicsRepository = topicsRepository
     }
 
-    func fetchTopics(completion: @escaping FetchTopicsListResult) {
+    func downloadTopicsList(completion: @escaping FetchTopicsListResult) {
         topicsServiceClient.fetchTopicsList { result in
             DispatchQueue.main.async {
                 switch result {
                 case .success(let topics):
-                    let sortedTopics = topics.sorted(by: {
-                        $0.title < $1.title
-                    })
-                    completion(.success(sortedTopics))
+                    topicsRepository.saveTopicsList(topics)
+                    completion(.success(topics))
                 case .failure(let error):
                     completion(.failure(error))
                 }
             }
         }
+    }
+
+    func fetchAllTopics() -> [Topic] {
+        topicsRepository.fetchAllTopics()
+    }
+
+    func fetchFavoriteTopics() -> [Topic] {
+        topicsRepository.fetchFavoriteTopics()
+    }
+
+    func updateFavoriteTopics() {
+        topicsRepository.saveChanges()
     }
 }

--- a/Production/govuk_ios/ViewModels/HomeViewModel.swift
+++ b/Production/govuk_ios/ViewModels/HomeViewModel.swift
@@ -3,10 +3,9 @@ import UIKit
 
 struct HomeViewModel {
     let configService: AppConfigServiceInterface
-    let topicsService: TopicsServiceInterface
     let searchButtonPrimaryAction: (() -> Void)?
     let recentActivityAction: (() -> Void)?
-    let topicAction: ((Topic) -> Void)?
+    let topicWidgetViewModel: TopicsWidgetViewModel
     var widgets: [WidgetView] {
         [
             searchWidget,
@@ -55,12 +54,9 @@ struct HomeViewModel {
     private var topicsWidget: WidgetView? {
         guard widgetEnabled(feature: .topics)
         else { return nil }
-        let viewModel = TopicsWidgetViewModel(
-            topicsService: topicsService,
-            topicAction: topicAction
-        )
+
         let content = TopicsWidgetView(
-            viewModel: viewModel
+            viewModel: topicWidgetViewModel
         )
         let widget = WidgetView(decorateView: false)
         widget.addContent(content)

--- a/Production/govuk_ios/ViewModels/Topics/EditTopicsViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/EditTopicsViewModel.swift
@@ -2,16 +2,20 @@ import Foundation
 
 final class EditTopicsViewModel: ObservableObject {
     @Published var topics: [Topic]
-    let topicsService: TopicsServiceInterface
+    private let analyticsService: AnalyticsServiceInterface
+    private let topicsService: TopicsServiceInterface
     let sections: [GroupedListSection]
-    var dismissAction: () -> Void
+    private let dismissAction: () -> Void
 
     init(topics: [Topic],
          topicsService: TopicsServiceInterface,
+         analyticsService: AnalyticsServiceInterface,
          dismissAction: @escaping () -> Void) {
         self.topics = topics
         self.dismissAction = dismissAction
         self.topicsService = topicsService
+        self.analyticsService = analyticsService
+
         var rows = [GroupedListRow]()
         topics.forEach { topic in
             rows.append(ToggleRow(id: topic.ref,
@@ -27,8 +31,12 @@ final class EditTopicsViewModel: ObservableObject {
                                       footer: nil)]
     }
 
-    func updateFovoriteTopics() {
+    func updateFavoriteTopics() {
         topicsService.updateFavoriteTopics()
         dismissAction()
+    }
+
+    func trackScreen(screen: TrackableScreen) {
+        analyticsService.track(screen: screen)
     }
 }

--- a/Production/govuk_ios/ViewModels/Topics/EditTopicsViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/EditTopicsViewModel.swift
@@ -2,11 +2,33 @@ import Foundation
 
 final class EditTopicsViewModel: ObservableObject {
     @Published var topics: [Topic]
+    let topicsService: TopicsServiceInterface
+    let sections: [GroupedListSection]
     var dismissAction: () -> Void
 
     init(topics: [Topic],
+         topicsService: TopicsServiceInterface,
          dismissAction: @escaping () -> Void) {
         self.topics = topics
         self.dismissAction = dismissAction
+        self.topicsService = topicsService
+        var rows = [GroupedListRow]()
+        topics.forEach { topic in
+            rows.append(ToggleRow(id: topic.ref,
+                                  title: topic.title,
+                                  isOn: topic.isFavorite,
+                                  action: { value in
+                topic.isFavorite = value
+            }))
+        }
+
+        sections = [GroupedListSection(heading: "",
+                                      rows: rows,
+                                      footer: nil)]
+    }
+
+    func updateFovoriteTopics() {
+        topicsService.updateFavoriteTopics()
+        dismissAction()
     }
 }

--- a/Production/govuk_ios/ViewModels/Topics/EditTopicsViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/EditTopicsViewModel.swift
@@ -18,12 +18,20 @@ final class EditTopicsViewModel: ObservableObject {
 
         var rows = [GroupedListRow]()
         topics.forEach { topic in
-            rows.append(ToggleRow(id: topic.ref,
-                                  title: topic.title,
-                                  isOn: topic.isFavorite,
-                                  action: { value in
-                topic.isFavorite = value
-            }))
+            let row = ToggleRow(
+                id: topic.ref,
+                title: topic.title,
+                isOn: topic.isFavorite,
+                action: { value in
+                    topic.isFavorite = value
+                    let event = AppEvent.toggleTopic(
+                        title: topic.title,
+                        isFavorite: topic.isFavorite
+                    )
+                    analyticsService.track(event: event)
+                }
+            )
+            rows.append(row)
         }
 
         sections = [GroupedListSection(heading: "",

--- a/Production/govuk_ios/ViewModels/Topics/EditTopicsViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/EditTopicsViewModel.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+final class EditTopicsViewModel: ObservableObject {
+    @Published var topics: [Topic]
+    var dismissAction: () -> Void
+
+    init(topics: [Topic],
+         dismissAction: @escaping () -> Void) {
+        self.topics = topics
+        self.dismissAction = dismissAction
+    }
+}

--- a/Production/govuk_ios/ViewModels/Topics/TopicsWidgetViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicsWidgetViewModel.swift
@@ -5,11 +5,14 @@ final class TopicsWidgetViewModel {
     var topics = [Topic]()
     let topicsService: TopicsServiceInterface
     let topicAction: ((Topic) -> Void)?
+    let editAction: (([Topic]) -> Void)?
 
     init(topicsService: TopicsServiceInterface,
-         topicAction: ((Topic) -> Void)?) {
+         topicAction: ((Topic) -> Void)?,
+         editAction: (([Topic]) -> Void)?) {
         self.topicsService = topicsService
         self.topicAction = topicAction
+        self.editAction = editAction
     }
 
     func fetchTopics(completion: FetchTopicsListResult?) {
@@ -27,5 +30,10 @@ final class TopicsWidgetViewModel {
         )
         analyticsService.track(event: event)
         action(topic)
+    }
+
+    @objc
+    func didTapEdit() {
+        editAction?(self.topics)
     }
 }

--- a/Production/govuk_ios/Views/Home/Topics/TopicCard.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicCard.swift
@@ -46,7 +46,7 @@ class TopicCard: UIView {
     private lazy var titleStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.spacing = 16
+        stackView.spacing = 8
         stackView.alignment = .bottom
         stackView.setContentHuggingPriority(.defaultLow, for: .vertical)
         return stackView

--- a/Production/govuk_ios/Views/Home/Topics/TopicCard.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicCard.swift
@@ -46,7 +46,7 @@ class TopicCard: UIView {
     private lazy var titleStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.spacing = 8
+        stackView.spacing = 0
         stackView.alignment = .bottom
         stackView.setContentHuggingPriority(.defaultLow, for: .vertical)
         return stackView

--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -66,6 +66,7 @@ class TopicsWidgetView: UIView {
             name: .NSManagedObjectContextDidSave,
             object: nil
         )
+        updateTopics(viewModel.favoriteTopics)
     }
 
     @objc

--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -4,6 +4,7 @@ class TopicsWidgetView: UIView {
     let viewModel: TopicsWidgetViewModel
 
     private var rowCount = 2
+
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.govUK.title3Semibold
@@ -11,6 +12,37 @@ class TopicsWidgetView: UIView {
         label.setContentHuggingPriority(.defaultLow, for: .vertical)
         label.text = String.home.localized("topicsWidgetTitle")
         return label
+    }()
+
+    private lazy var editButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle(String.common.localized("editButtonTitle"), for: .normal)
+        button.titleLabel?.font = UIFont.govUK.bodySemibold
+        button.addTarget(viewModel,
+                         action: #selector(viewModel.didTapEdit),
+                         for: .touchUpInside
+        )
+        return button
+    }()
+
+    private lazy var headerStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 16
+        stackView.alignment = .bottom
+        stackView.distribution = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    private lazy var cardStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 16
+        stackView.alignment = .leading
+        stackView.distribution = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
     }()
 
     private lazy var stackView: UIStackView = {
@@ -39,7 +71,10 @@ class TopicsWidgetView: UIView {
     }
 
     private func configureUI() {
-        stackView.addArrangedSubview(titleLabel)
+        headerStackView.addArrangedSubview(titleLabel)
+        headerStackView.addArrangedSubview(editButton)
+        stackView.addArrangedSubview(headerStackView)
+        stackView.addArrangedSubview(cardStackView)
         addSubview(stackView)
     }
 
@@ -50,15 +85,30 @@ class TopicsWidgetView: UIView {
             stackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
         ])
+
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: headerStackView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: headerStackView.trailingAnchor)
+        ])
+
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: cardStackView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: cardStackView.trailingAnchor)
+        ])
     }
 
     private func updateTopics(_ topics: [Topic]) {
+        cardStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         for index in 0..<topics.count where index % rowCount == 0 {
             let rowStack = createNewRow(startingAt: index, of: topics)
             rowStack.translatesAutoresizingMaskIntoConstraints = false
-            stackView.addArrangedSubview(rowStack)
-            rowStack.leadingAnchor.constraint(equalTo: stackView.leadingAnchor).isActive = true
-            rowStack.trailingAnchor.constraint(equalTo: stackView.trailingAnchor).isActive = true
+            cardStackView.addArrangedSubview(rowStack)
+            rowStack.leadingAnchor.constraint(
+                equalTo: cardStackView.leadingAnchor
+            ).isActive = true
+            rowStack.trailingAnchor.constraint(
+                equalTo: cardStackView.trailingAnchor
+            ).isActive = true
         }
     }
 
@@ -97,14 +147,6 @@ class TopicsWidgetView: UIView {
         return topicCard
     }
 
-    private func resetRows() {
-        stackView.arrangedSubviews.forEach { view in
-            if view is UIStackView {
-                view.removeFromSuperview()
-            }
-        }
-    }
-
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -113,7 +155,6 @@ class TopicsWidgetView: UIView {
         super.traitCollectionDidChange(previousTraitCollection)
         let sizeClass = UITraitCollection.current.verticalSizeClass
         rowCount = sizeClass == .regular ? 2 : 4
-        resetRows()
         updateTopics(viewModel.topics)
     }
 }

--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -71,7 +71,9 @@ class TopicsWidgetView: UIView {
 
     @objc
     private func topicsDidUpdate(notification: Notification) {
-        updateTopics(viewModel.favoriteTopics)
+        DispatchQueue.main.async {
+            self.updateTopics(self.viewModel.favoriteTopics)
+        }
     }
 
     private func configureUI() {

--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -60,14 +60,17 @@ class TopicsWidgetView: UIView {
         super.init(frame: .zero)
         configureUI()
         configureConstraints()
-        viewModel.fetchTopics { result in
-            switch result {
-            case .success:
-                self.updateTopics(viewModel.topics)
-            case .failure:
-                break
-            }
-        }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(topicsDidUpdate),
+            name: .NSManagedObjectContextDidSave,
+            object: nil
+        )
+    }
+
+    @objc
+    private func topicsDidUpdate(notification: Notification) {
+        updateTopics(viewModel.favoriteTopics)
     }
 
     private func configureUI() {
@@ -154,7 +157,9 @@ class TopicsWidgetView: UIView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         let sizeClass = UITraitCollection.current.verticalSizeClass
-        rowCount = sizeClass == .regular ? 2 : 4
-        updateTopics(viewModel.topics)
+        if sizeClass != previousTraitCollection?.verticalSizeClass {
+            rowCount = sizeClass == .regular ? 2 : 4
+            updateTopics(viewModel.favoriteTopics)
+        }
     }
 }

--- a/Production/govuk_ios/Views/Topics/EditTopicsView.swift
+++ b/Production/govuk_ios/Views/Topics/EditTopicsView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct EditTopicsView: View {
+    @StateObject var viewModel: EditTopicsViewModel
+
+    var body: some View {
+        Text("Edit Topics")
+            .navigationTitle("Edit your topics")
+            .toolbar {
+                HStack {
+                    Spacer()
+                    Button("Done") {
+                        viewModel.dismissAction()
+                    }
+                }
+            }
+    }
+}
+
+#Preview {
+    EditTopicsView(viewModel: EditTopicsViewModel(topics: [],
+                                                  dismissAction: { }))
+}

--- a/Production/govuk_ios/Views/Topics/EditTopicsView.swift
+++ b/Production/govuk_ios/Views/Topics/EditTopicsView.swift
@@ -5,17 +5,19 @@ struct EditTopicsView: View {
 
     var body: some View {
         VStack {
-            Text("Topics you select will be shown on ")
+            Text(String.topics.localized("editTopicsSubtitle"))
                 .multilineTextAlignment(.leading)
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
             ScrollView {
                 GroupedList(content: viewModel.sections)
             }
         }
-        .navigationTitle("Edit your topics")
+        .navigationTitle(String.topics.localized("editTopicsTitle"))
         .toolbar {
             HStack {
                 Spacer()
-                Button("Done") {
+                Button(String.topics.localized("doneButtonTitle")) {
                     viewModel.updateFavoriteTopics()
                 }
             }

--- a/Production/govuk_ios/Views/Topics/EditTopicsView.swift
+++ b/Production/govuk_ios/Views/Topics/EditTopicsView.swift
@@ -17,13 +17,17 @@ struct EditTopicsView: View {
         .toolbar {
             HStack {
                 Spacer()
-                Button(String.topics.localized("doneButtonTitle")) {
-                    viewModel.updateFavoriteTopics()
-                }
+                doneButton
             }
         }
         .onAppear {
             viewModel.trackScreen(screen: self)
+        }
+    }
+
+    private var doneButton: some View {
+        Button(String.topics.localized("doneButtonTitle")) {
+            viewModel.updateFavoriteTopics()
         }
     }
 }

--- a/Production/govuk_ios/Views/Topics/EditTopicsView.swift
+++ b/Production/govuk_ios/Views/Topics/EditTopicsView.swift
@@ -4,20 +4,21 @@ struct EditTopicsView: View {
     @StateObject var viewModel: EditTopicsViewModel
 
     var body: some View {
-        Text("Edit Topics")
-            .navigationTitle("Edit your topics")
-            .toolbar {
-                HStack {
-                    Spacer()
-                    Button("Done") {
-                        viewModel.dismissAction()
-                    }
+        VStack {
+            Text("Topics you select will be shown on ")
+                .multilineTextAlignment(.leading)
+            ScrollView {
+                GroupedList(content: viewModel.sections)
+            }
+        }
+        .navigationTitle("Edit your topics")
+        .toolbar {
+            HStack {
+                Spacer()
+                Button("Done") {
+                    viewModel.updateFovoriteTopics()
                 }
             }
+        }
     }
-}
-
-#Preview {
-    EditTopicsView(viewModel: EditTopicsViewModel(topics: [],
-                                                  dismissAction: { }))
 }

--- a/Production/govuk_ios/Views/Topics/EditTopicsView.swift
+++ b/Production/govuk_ios/Views/Topics/EditTopicsView.swift
@@ -16,9 +16,17 @@ struct EditTopicsView: View {
             HStack {
                 Spacer()
                 Button("Done") {
-                    viewModel.updateFovoriteTopics()
+                    viewModel.updateFavoriteTopics()
                 }
             }
         }
+        .onAppear {
+            viewModel.trackScreen(screen: self)
+        }
     }
+}
+
+extension EditTopicsView: TrackableScreen {
+    var trackingTitle: String? { "Edit your topics" }
+    var trackingName: String { "Edit your topics" }
 }

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.EditTopicsViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.EditTopicsViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f337d7ef657d0edc3a066efaa8a090c9f882a6b5ae19a98c558883eeeaeaf6af
+size 133705

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.EditTopicsViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.EditTopicsViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce2bea0a02a4d6eabba6e56f7c6cd3a19720e5d5fa83e7711547581bb955fba1
+size 125830

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.HomeViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.HomeViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:decbb4922abdc7a189163ccb88efc5e0184983b5e5ba87cdda88c9d717fd4a62
-size 155725
+oid sha256:b9a7a74b5c3e032f3c29a8ad0248f5f52cdb6e1aa19c73f74a99f2d056ac8244
+size 157260

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.HomeViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.HomeViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99932602e83cf49ae48ef7759652b0c2264531eadb63e8a57cf3d2955031fb0b
-size 154025
+oid sha256:7b419aa792f37f131125a8a63b6d69e8fc6621958b41e5452d1cacb9f8febdc5
+size 155716

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/EditTopicsViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/EditTopicsViewControllerSnapshotTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+import UIKit
+
+@testable import govuk_ios
+
+@MainActor
+final class EditTopicsViewControllerSnapshotTests: SnapshotTestCase {
+    
+    private let mockTopicsService = MockTopicsService()
+    
+    func test_loadInNavigationController_light_rendersCorrectly() {
+        VerifySnapshotInNavigationController(
+            viewController: viewController(),
+            mode: .light
+        )
+    }
+
+    func test_loadInNavigationController_dark_rendersCorrectly() {
+        VerifySnapshotInNavigationController(
+            viewController: viewController(),
+            mode: .dark
+        )
+    }
+    
+    private func viewController() -> UIViewController {
+        let viewModel = EditTopicsViewModel(
+            topics: mockTopicsService.fetchAllTopics(),
+            topicsService: mockTopicsService,
+            analyticsService: MockAnalyticsService(),
+            dismissAction: { }
+        )
+        let view = EditTopicsView(
+            viewModel: viewModel
+        )
+        
+        return HostingViewController(rootView: view)
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/HomeViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/HomeViewControllerSnapshotTests.swift
@@ -24,11 +24,11 @@ class HomeViewControllerSnapshotTests: SnapshotTestCase {
 
     private var viewController: HomeViewController {
         let topicService = MockTopicsService()
+        topicService._receivedFetchTopicsResult = MockTopicsService.testTopicsResult
         let topicsViewModel = TopicsWidgetViewModel(
             topicsService: topicService,
             topicAction: { _ in },
             editAction: { _ in })
-        topicService._receivedFetchTopicsResult = MockTopicsService.testTopicsResult
         let viewModel = HomeViewModel(
             configService: MockAppConfigService(),
             searchButtonPrimaryAction: { },

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/HomeViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/HomeViewControllerSnapshotTests.swift
@@ -24,13 +24,16 @@ class HomeViewControllerSnapshotTests: SnapshotTestCase {
 
     private var viewController: HomeViewController {
         let topicService = MockTopicsService()
+        let topicsViewModel = TopicsWidgetViewModel(
+            topicsService: topicService,
+            topicAction: { _ in },
+            editAction: { _ in })
         topicService._receivedFetchTopicsResult = MockTopicsService.testTopicsResult
         let viewModel = HomeViewModel(
             configService: MockAppConfigService(),
-            topicsService: topicService,
             searchButtonPrimaryAction: { },
             recentActivityAction: { },
-            topicAction: { _ in }
+            topicWidgetViewModel: topicsViewModel
         )
         return HomeViewController(viewModel: viewModel)
     }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Extensions/Analytics/AppEvent+ConvenienceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Extensions/Analytics/AppEvent+ConvenienceTests.swift
@@ -91,7 +91,7 @@ struct AppEvent_ConvenienceTests {
     }
 
     @Test
-    func searchItemNavigation_returnsExpectedResuls() {
+    func searchItemNavigation_returnsExpectedResult() {
         let expectedTitle = UUID().uuidString
         let expectedURL = URL(string: "https://www.gov.uk/random")!
         let result = AppEvent.searchItemNavigation(
@@ -107,6 +107,22 @@ struct AppEvent_ConvenienceTests {
         #expect(result.params?["type"] as? String == "SearchResult")
         #expect(result.params?["external"] as? Bool == true)
         #expect(result.params?["language"] as? String == "en")
+    }
+    
+    @Test(arguments:[true, false])
+    func toggleTopicOn_returnsExpectedResult(isFavorite: Bool) {
+        let expectedTitle = UUID().uuidString
+        let expectedValue = isFavorite ? "On" : "Off"
+        let result = AppEvent.toggleTopic(
+            title: expectedTitle,
+            isFavorite: isFavorite
+        )
+        #expect(result.name == "Function")
+        #expect(result.params?.count == 4)
+        #expect(result.params?["text"] as? String == expectedTitle)
+        #expect(result.params?["type"] as? String == "toggle")
+        #expect(result.params?["section"] as? String == "Topics")
+        #expect(result.params?["action"] as? String == expectedValue)
     }
 
     @Test

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Extensions/Analytics/AppEvent+ConvenienceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Extensions/Analytics/AppEvent+ConvenienceTests.swift
@@ -110,7 +110,7 @@ struct AppEvent_ConvenienceTests {
     }
     
     @Test(arguments:[true, false])
-    func toggleTopicOn_returnsExpectedResult(isFavorite: Bool) {
+    func toggleTopic_returnsExpectedResult(isFavorite: Bool) {
         let expectedTitle = UUID().uuidString
         let expectedValue = isFavorite ? "On" : "Off"
         let result = AppEvent.toggleTopic(
@@ -126,7 +126,7 @@ struct AppEvent_ConvenienceTests {
     }
 
     @Test
-    func function_returnsExpectedResuls() {
+    func function_returnsExpectedResult() {
         let expectedText = UUID().uuidString
         let expectedType = UUID().uuidString
         let expectedSection = UUID().uuidString
@@ -146,7 +146,7 @@ struct AppEvent_ConvenienceTests {
     }
 
     @Test
-    func buttonFunction_returnsExpectedResuls() {
+    func buttonFunction_returnsExpectedResult() {
         let expectedText = UUID().uuidString
         let expectedSection = UUID().uuidString
         let expectedAction = UUID().uuidString

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
@@ -67,4 +67,15 @@ class MockViewControllerBuilder: ViewControllerBuilder {
     override func topicDetail(topic: Topic, analyticsService: any AnalyticsServiceInterface) -> UIViewController {
         return _stubbedTopicDetailViewController ?? UIViewController()
     }
+    
+    var _stubbedEditTopicsViewController: UIViewController?
+    var _receivedDoneButtonAction: (() -> Void)?
+    override func editTopics(
+        _ topics: [Topic],
+        analyticsService: any AnalyticsServiceInterface,
+        topicsService: any TopicsServiceInterface,
+        dismissAction: @escaping () -> Void) -> UIViewController {
+            _receivedDoneButtonAction = dismissAction
+            return _stubbedEditTopicsViewController ?? UIViewController()
+        }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
@@ -38,9 +38,8 @@ class MockViewControllerBuilder: ViewControllerBuilder {
     var _stubbedHomeViewController: UIViewController?
     override func home(searchButtonPrimaryAction: @escaping () -> Void,
                        configService: AppConfigServiceInterface,
-                       topicsService: TopicsServiceInterface,
                        recentActivityAction: @escaping () -> Void,
-                       topicAction: @escaping ((Topic) -> Void)) -> UIViewController {
+                       topicWidgetViewModel: TopicsWidgetViewModel) -> UIViewController {
         return _stubbedHomeViewController ?? UIViewController()
     }
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Repositories/MockTopicsRepository.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Repositories/MockTopicsRepository.swift
@@ -4,20 +4,25 @@ import Foundation
 
 class MockTopicsRepository: TopicsRepositoryInterface {
     
+    var _didCallSaveTopicsList = false
     func saveTopicsList(_ topicResponses: [TopicResponseItem]) {
-        
+        self._didCallSaveTopicsList = true
     }
     
+    var _didCallFetchFavorites = false
     func fetchFavoriteTopics() -> [Topic] {
-        []
+        self._didCallFetchFavorites = true
+        return []
     }
     
+    var _didCallFetchAll = false
     func fetchAllTopics() -> [Topic] {
-        []
+        self._didCallFetchAll = true
+        return []
     }
     
-    
+    var _didCallSaveChanges = false
     func saveChanges() {
-        
+        self._didCallSaveChanges = true
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Repositories/MockTopicsRepository.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Repositories/MockTopicsRepository.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@testable import govuk_ios
+
+class MockTopicsRepository: TopicsRepositoryInterface {
+    
+    func saveTopicsList(_ topicResponses: [TopicResponseItem]) {
+        
+    }
+    
+    func fetchFavoriteTopics() -> [Topic] {
+        []
+    }
+    
+    func fetchAllTopics() -> [Topic] {
+        []
+    }
+    
+    
+    func saveChanges() {
+        
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
@@ -114,7 +114,7 @@ struct CoordinatorBuilderTests {
         let mockNavigationController = MockNavigationController()
         let coordinator = subject.editTopics(
             [Topic](),
-            navigationControlloer: mockNavigationController,
+            navigationController: mockNavigationController,
             didDismissAction: { }
         )
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
@@ -96,7 +96,7 @@ struct CoordinatorBuilderTests {
         #expect(coordinator is RecentActivityCoordinator)
     }
     
-    @MainActor
+    @Test
     func topicDetail_returnsExpectedResult() {
         let subject = CoordinatorBuilder(container: Container())
         let mockNavigationController = MockNavigationController()
@@ -108,7 +108,7 @@ struct CoordinatorBuilderTests {
         #expect(coordinator is TopicsCoordinator)
     }
     
-    @MainActor
+    @Test
     func editTopics_returnsExpectedResult() {
         let subject = CoordinatorBuilder(container: Container())
         let mockNavigationController = MockNavigationController()

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
@@ -97,14 +97,27 @@ struct CoordinatorBuilderTests {
     }
     
     @MainActor
-    func test_topicDetail_returnsExpectedResult() {
+    func topicDetail_returnsExpectedResult() {
         let subject = CoordinatorBuilder(container: Container())
         let mockNavigationController = MockNavigationController()
         let coordinator = subject.topicDetail(
-            Topic(ref: "ref", title: "title"),
+            Topic(),
             navigationController: mockNavigationController
         )
 
         #expect(coordinator is TopicsCoordinator)
+    }
+    
+    @MainActor
+    func editTopics_returnsExpectedResult() {
+        let subject = CoordinatorBuilder(container: Container())
+        let mockNavigationController = MockNavigationController()
+        let coordinator = subject.editTopics(
+            [Topic](),
+            navigationControlloer: mockNavigationController,
+            didDismissAction: { }
+        )
+
+        #expect(coordinator is EditTopicsCoordinator)
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
@@ -36,12 +36,16 @@ struct ViewControllerBuilderTests {
     @Test
     func home_returnsExpectedResult() {
         let subject = ViewControllerBuilder()
+        let viewModel = TopicsWidgetViewModel(
+            topicsService: MockTopicsService(),
+            topicAction: { _ in },
+            editAction: { _ in }
+        )
         let result = subject.home(
             searchButtonPrimaryAction: { () -> Void in },
             configService: MockAppConfigService(),
-            topicsService: MockTopicsService(),
             recentActivityAction: {},
-            topicAction: { _ in }
+            topicWidgetViewModel: viewModel
         )
 
         #expect(result is HomeViewController)
@@ -90,7 +94,7 @@ struct ViewControllerBuilderTests {
     func topicDetail_returnsExpectedResult() async throws {
         let subject = ViewControllerBuilder()
         let result = subject.topicDetail(
-            topic: Topic(ref: "ref", title: "Title"),
+            topic: Topic(),
             analyticsService: MockAnalyticsService()
         )
         

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
@@ -101,4 +101,18 @@ struct ViewControllerBuilderTests {
         let rootView = (result as? HostingViewController<TopicDetailView>)?.rootView
         #expect(rootView != nil) 
     }
+    
+    @Test
+    func editTopics_returnsExpectedResult() async throws {
+        let subject = ViewControllerBuilder()
+        let result = subject.editTopics(
+            [],
+            analyticsService: MockAnalyticsService(),
+            topicsService: MockTopicsService(),
+            dismissAction: { }
+        )
+        
+        let rootView = (result as? HostingViewController<EditTopicsView>)?.rootView
+        #expect(rootView != nil)
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/EditTopicsCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/EditTopicsCoordinatorTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import UIKit
+@testable import govuk_ios
+
+@Suite
+@MainActor
+struct EditTopicsCoordinatorTests {
+    
+    @Test
+    func start_setsEditTopicsView() throws {
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let mockAnalyticsService = MockAnalyticsService()
+        let mockTopicsService = MockTopicsService()
+        let expectedViewController = UIViewController()
+        let navigationController = UINavigationController()
+        
+        mockViewControllerBuilder._stubbedEditTopicsViewController = expectedViewController
+        
+        let subject = EditTopicsCoordinator(
+            navigationController: navigationController,
+            analyticsService: mockAnalyticsService,
+            topicsService: mockTopicsService,
+            viewControllerBuilder: mockViewControllerBuilder,
+            topics: [],
+            dismissed: { }
+        )
+        
+        subject.start()
+        
+        #expect(navigationController.viewControllers.first == expectedViewController)
+    }
+    
+    @Test
+    func dragToDismiss_callsDismissed() async {
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let mockAnalyticsService = MockAnalyticsService()
+        let mockTopicsService = MockTopicsService()
+        let expectedViewController = UIViewController()
+        let navigationController = UINavigationController()
+
+        mockViewControllerBuilder._stubbedEditTopicsViewController = expectedViewController
+
+        let dismissed = await withCheckedContinuation { continuation in
+            let subject = EditTopicsCoordinator(
+                navigationController: navigationController,
+                analyticsService: mockAnalyticsService,
+                topicsService: mockTopicsService,
+                viewControllerBuilder: mockViewControllerBuilder,
+                topics: [],
+                dismissed: {
+                    continuation.resume(returning: true)
+                }
+            )
+            subject.start()
+
+            subject.presentationControllerDidDismiss(subject.root.presentationController!)
+        }
+
+        #expect(dismissed)
+    }
+    
+    @Test
+    func doneButton_callsDismissed() async {
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let mockAnalyticsService = MockAnalyticsService()
+        let mockTopicsService = MockTopicsService()
+        let expectedViewController = UIViewController()
+        let mockNavigationController = MockNavigationController()
+
+        mockViewControllerBuilder._stubbedEditTopicsViewController = expectedViewController
+
+        _ = await withCheckedContinuation { continuation in
+            let subject = EditTopicsCoordinator(
+                navigationController: mockNavigationController,
+                analyticsService: mockAnalyticsService,
+                topicsService: mockTopicsService,
+                viewControllerBuilder: mockViewControllerBuilder,
+                topics: [],
+                dismissed: {
+                    continuation.resume(returning: true)
+                }
+            )
+            subject.start()
+            
+            //Simulate view controller calling close
+            mockViewControllerBuilder._receivedDoneButtonAction?()
+        }
+
+        #expect(mockNavigationController._dismissCalled)
+        #expect(mockNavigationController._receivedDismissAnimated == true)
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/TopicsCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/TopicsCoordinatorTests.swift
@@ -19,7 +19,7 @@ struct TopicsCoordinatorTests {
             navigationController: navigationController,
             analyticsService: mockAnalyticsService,
             viewControllerBuilder: mockViewControllerBuilder,
-            topic: Topic(ref: "ref", title: "Title")
+            topic: Topic()
         )
         
         subject.start()

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Extensions/Foundation/String+ExtensionsTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Extensions/Foundation/String+ExtensionsTests.swift
@@ -35,6 +35,12 @@ struct String_ExtensionsTests {
         let sut = String.onboarding
         #expect(sut.tableName == "Onboarding")
     }
+    
+    @Test
+    func topics_hasCorrectValues() {
+        let sut = String.topics
+        #expect(sut.tableName == "Topics")
+    }
 
     @Test
     func localized_returnsExpectedResult() {

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Models/EditTopicsViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Models/EditTopicsViewModelTests.swift
@@ -1,0 +1,57 @@
+import Testing
+
+@testable import govuk_ios
+
+struct EditTopicsViewModelTests {
+    
+    let coreData = CoreDataRepository.arrangeAndLoad
+    let topicService = MockTopicsService()
+    let analyticsService = MockAnalyticsService()
+    
+    @Test
+    func updateFavorites_doesSaveAndDismiss() async throws {
+        var dismissActionCalled = false
+        let sut = EditTopicsViewModel(
+            topics: [],
+            topicsService: topicService,
+            analyticsService: analyticsService,
+            dismissAction: {
+                dismissActionCalled = true
+            }
+        )
+        
+        sut.updateFavoriteTopics()
+        #expect(topicService._didUpdateFavoritesCalled)
+        #expect(dismissActionCalled)
+    }
+    
+    @Test func initViewModel_doesCreateSectionsCorrectly() async throws {
+        let sut = EditTopicsViewModel(
+            topics: createTopics(),
+            topicsService: topicService,
+            analyticsService: analyticsService,
+            dismissAction: { }
+        )
+        
+        try #require(sut.sections.count == 1)
+        try #require(sut.sections[0].rows.count == 3)
+        let row = try #require(sut.sections[0].rows[0] as? ToggleRow)
+        #expect(row.title == "title0")
+        row.action(true)
+        #expect(sut.topics[0].isFavorite)
+    }
+}
+
+private extension EditTopicsViewModelTests {
+    func createTopics() -> [Topic] {
+        var topics = [Topic]()
+        for index in 0..<3 {
+            let topic = Topic(context: coreData.viewContext)
+            topic.ref = "ref\(index)"
+            topic.title = "title\(index)"
+            topic.isFavorite = false
+            topics.append(topic)
+        }
+        return topics
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Models/TopicTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Models/TopicTests.swift
@@ -36,7 +36,11 @@ struct TopicTests {
         ]
     ))
     func topic_iconName_returnsCorrectValue(ref: String, iconName: String) {
-        let topic = Topic(ref: ref, title: "Title")
+        let coreData = CoreDataRepository.arrange
+        
+        let topic = Topic(context: coreData.viewContext)
+        topic.ref = ref
+        topic.title = "Title"
         #expect(topic.iconName == iconName)
     }
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Models/TopicsWidgetViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Models/TopicsWidgetViewModelTests.swift
@@ -71,7 +71,7 @@ struct TopicsWidgetViewModelTests {
     }
     
     @Test
-    func didTapTopic_sendsEvent() async throws {
+    func didTapTopic_sendsEvent() {
         let mockAnalyticsService = MockAnalyticsService()
         Container.shared.analyticsService.register { mockAnalyticsService }
         let sut = TopicsWidgetViewModel(
@@ -89,7 +89,7 @@ struct TopicsWidgetViewModelTests {
     }
     
     @Test
-    func didTapEdit_sendsEvent() async throws {
+    func didTapEdit_sendsEvent() {
         let mockAnalyticsService = MockAnalyticsService()
         Container.shared.analyticsService.register { mockAnalyticsService }
         let sut = TopicsWidgetViewModel(

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Models/TopicsWidgetViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Models/TopicsWidgetViewModelTests.swift
@@ -5,78 +5,102 @@ import Factory
 
 @Suite
 struct TopicsWidgetViewModelTests {
+    
+    let coreData = CoreDataRepository.arrangeAndLoad
+    let topicService = MockTopicsService()
 
     @Test
-    func fetchTopics_success_returnsExpectedData() async throws {
-        let topicService = MockTopicsService()
+    func initializeModel_downloadSuccess_returnsExpectedData() async throws {
+        
         topicService._receivedFetchTopicsResult = MockTopicsService.testTopicsResult
 
         let sut = TopicsWidgetViewModel(
             topicsService: topicService,
-            topicAction: { _ in }
+            topicAction: { _ in },
+            editAction: { _ in }
         )
-        let result = await withCheckedContinuation { continuation in
-            sut.fetchTopics { result in
-                continuation.resume(returning: result)
-            }
-        }
         
-        let topics = try? result.get()
-        #expect(topics?.count == 3)
-        #expect(topics?.first?.ref == "driving-transport")
+        #expect(topicService._dataReceived == true)
+        #expect(sut.downloadError == nil)
     }
     
     @Test
-    func fetchTopics_failure_returnsExpectedResult() async throws {
-        let topicService = MockTopicsService()
+    func initializeModel_downloadFailure_returnsExpectedResult() async throws {
         topicService._receivedFetchTopicsResult = MockTopicsService.testTopicsFailure
 
         let sut = TopicsWidgetViewModel(
             topicsService: topicService,
-            topicAction: { _ in }
+            topicAction: { _ in },
+            editAction: { _ in }
         )
-        let result = await withCheckedContinuation { continuation in
-            sut.fetchTopics { result in
-                continuation.resume(returning: result)
-            }
-        }
         
-        let topics = try? result.get()
-        let error = result.getError()
-        #expect(topics == nil)
-        #expect(error == .apiUnavailable)
-        
+        #expect(topicService._dataReceived == false)
+        #expect(sut.downloadError == .decodingError)
     }
     
     @Test
     func didTapTopic_invokesExpectedAction() async throws {
-        let topicService = MockTopicsService()
         Container.shared.analyticsService.register { MockAnalyticsService() }
         var expectedValue = false
         let sut = TopicsWidgetViewModel(
             topicsService: topicService,
             topicAction: { _ in
                 expectedValue = true
+            },
+            editAction: { _ in }
+        )
+        
+        sut.didTapTopic(Topic(context: coreData.viewContext))
+        #expect(expectedValue == true)
+    }
+    
+    @Test
+    func didTapEdit_invokesExpectedAction() async throws {
+        Container.shared.analyticsService.register { MockAnalyticsService() }
+        var expectedValue = false
+        let sut = TopicsWidgetViewModel(
+            topicsService: topicService,
+            topicAction: { _ in },
+            editAction: { _ in
+                expectedValue = true
             }
         )
         
-        sut.didTapTopic(Topic(ref: "test", title: "Title"))
+        sut.didTapEdit()
         #expect(expectedValue == true)
     }
     
     @Test
     func didTapTopic_sendsEvent() async throws {
-        let topicService = MockTopicsService()
         let mockAnalyticsService = MockAnalyticsService()
         Container.shared.analyticsService.register { mockAnalyticsService }
         let sut = TopicsWidgetViewModel(
             topicsService: topicService,
-            topicAction: { _ in }
+            topicAction: { _ in },
+            editAction: { _ in }
         )
         
-        sut.didTapTopic(Topic(ref: "test", title: "Title"))
+        let testTopic = Topic(context: coreData.viewContext)
+        testTopic.ref = "test"
+        testTopic.title = "Title"
+        sut.didTapTopic(testTopic)
         #expect(mockAnalyticsService._trackedEvents.count == 1)
         #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "test")
+    }
+    
+    @Test
+    func didTapEdit_sendsEvent() async throws {
+        let mockAnalyticsService = MockAnalyticsService()
+        Container.shared.analyticsService.register { mockAnalyticsService }
+        let sut = TopicsWidgetViewModel(
+            topicsService: topicService,
+            topicAction: { _ in },
+            editAction: { _ in }
+        )
+        
+        sut.didTapEdit()
+        #expect(mockAnalyticsService._trackedEvents.count == 1)
+        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "EditTopics")
     }
 
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Repositories/TopicsRepositoryTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Repositories/TopicsRepositoryTests.swift
@@ -24,7 +24,7 @@ struct TopicsRepositoryTests {
     }
     
     @Test func saveTopicsList_newTopicsNotFavoritedAfterInitialLaunch() async throws {
-        // Given I have starte the app once and gotten topics
+        // Given I have started the app the first time, and gotten topics
         var topicResponseItems = try #require(try? MockTopicsService.testTopicsResult.get())
         sut.saveTopicsList(topicResponseItems)
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Repositories/TopicsRepositoryTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Repositories/TopicsRepositoryTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+import CoreData
+
+@testable import govuk_ios
+
+struct TopicsRepositoryTests {
+    
+    let coreData = CoreDataRepository.arrangeAndLoad
+    var sut: TopicsRepository {
+        TopicsRepository(coreData: coreData)
+    }
+
+    @Test
+    func saveTopicsList_doesSaveResponseItems() async throws {
+        let topicResponseItems = try #require(try? MockTopicsService.testTopicsResult.get())
+        sut.saveTopicsList(topicResponseItems)
+        let topics = sut.fetchAllTopics()
+        #expect(topics.count == 3)
+        #expect(topics.first?.title == "Business")
+        #expect(topics.first?.ref == "business")
+        #expect(topics.filter { $0.isFavorite == true }.count == 3)
+        
+    }
+    
+    @Test func saveTopicsList_newTopicsNotFavoritedAfterInitialLaunch() async throws {
+        // Given I have starte the app once and gotten topics
+        var topicResponseItems = try #require(try? MockTopicsService.testTopicsResult.get())
+        sut.saveTopicsList(topicResponseItems)
+
+        // When I start the app again and new topics are available to save
+        let newItem = TopicResponseItem(ref: "new-item", title: "New Item")
+        topicResponseItems.append(newItem)
+        sut.saveTopicsList(topicResponseItems)
+        
+        // Then the new item will not be favorited
+        let topics = sut.fetchAllTopics()
+        #expect(topics.count == 4)
+        let newTopic = try #require(topics.first(where: { $0.ref == "new-item" }))
+        #expect(newTopic.isFavorite == false)
+    }
+
+    @Test
+    func fetchFavoriteTopics_onlyReturnsFavorites() async throws {
+        createTopics(context: coreData.viewContext)
+        let favorites = sut.fetchFavoriteTopics()
+        #expect(favorites.count == 1)
+        #expect(favorites.first?.title == "title3")
+    }
+    
+    @Test func saveChanges_persistsDataAsExpected() async throws {
+        // Given I save on the view context
+        createTopics(context: coreData.viewContext)
+        // After I save them
+        sut.saveChanges()
+        // I should be able to fetch on another context
+        let request = Topic.fetchRequest()
+        let context = coreData.backgroundContext
+        let topics = try #require(try? context.fetch(request))
+        #expect(topics.count == 4)
+    }
+    
+}
+
+private extension TopicsRepositoryTests {
+    @discardableResult
+    func createTopics(context: NSManagedObjectContext) -> [Topic] {
+        var topics = [Topic]()
+        for index in 0..<4 {
+            let topic = Topic(context: context)
+            topic.ref = "ref\(index)"
+            topic.title = "title\(index)"
+            topic.isFavorite = index == 3 ? true : false
+            topics.append(topic)
+        }
+        
+        return topics
+    }
+
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/TopicsServiceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/TopicsServiceTests.swift
@@ -5,36 +5,37 @@ import Testing
 struct TopicsServiceTests {
     var sut: TopicsService!
     var topicsServiceClient: MockTopicsServiceClient!
+    var topicsRepository: MockTopicsRepository!
     
     init() {
         topicsServiceClient = MockTopicsServiceClient()
+        topicsRepository = MockTopicsRepository()
         sut = TopicsService(
-            topicsServiceClient: topicsServiceClient
+            topicsServiceClient: topicsServiceClient,
+            topicsRepository: topicsRepository
         )
     }
     
     @Test
     func topicsService_success_returnsExpectedData() async {
         let result = await withCheckedContinuation { continuation in
-            sut.fetchTopics { result in
+            sut.downloadTopicsList { result in
                 continuation.resume(returning: result)
             }
             topicsServiceClient._receivedFetchTopicsCompletion?(
                 MockTopicsService.testTopicsResult
             )
+            
         }
         let topicsList = try? result.get()
         #expect(topicsList?.count == 3)
-        // Topics should be sorted
-        #expect(topicsList?[0].title == "Business")
-        #expect(topicsList?[1].title == "Care")
-        #expect(topicsList?[2].title == "Driving & Transport")
+        #expect(topicsRepository._didCallSaveTopicsList == true)
     }
     
     @Test
     func topicsService_failure_returnsExpectedResult() async {
         let result = await withCheckedContinuation { continuation in
-            sut.fetchTopics { result in
+            sut.downloadTopicsList { result in
                 continuation.resume(returning: result)
             }
             topicsServiceClient._receivedFetchTopicsCompletion?(
@@ -43,7 +44,26 @@ struct TopicsServiceTests {
         }
 
         #expect((try? result.get()) == nil)
-        #expect(result.getError() == .apiUnavailable)
+        #expect(result.getError() == .decodingError)
+        #expect(topicsRepository._didCallSaveTopicsList == false)
+    }
+    
+    @Test
+    func fetchAllTopics_fetchesFromRepository() async {
+        _ = sut.fetchAllTopics()
+        #expect(topicsRepository._didCallFetchAll ?? false)
+    }
+    
+    @Test
+    func fetchFavoriteTopics_fetchesFromRepository() async {
+        _ = sut.fetchFavoriteTopics()
+        #expect(topicsRepository._didCallFetchFavorites)
+    }
+    
+    @Test
+    func updateFavorites_savesChangesToRepository() async {
+        sut.updateFavoriteTopics()
+        #expect(topicsRepository._didCallSaveChanges)
     }
 }
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/HomeViewControllerTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/HomeViewControllerTests.swift
@@ -11,12 +11,16 @@ struct HomeViewControllerTests {
 
     @Test
     func init_hasExpectedValues() {
+        let topicsViewModel = TopicsWidgetViewModel(
+            topicsService: MockTopicsService(),
+            topicAction: { _ in },
+            editAction: { _ in }
+        )
         let viewModel = HomeViewModel(
             configService: MockAppConfigService(),
-            topicsService: MockTopicsService(),
             searchButtonPrimaryAction: { () -> Void in _ = true },
             recentActivityAction: { },
-            topicAction: { _ in }
+            topicWidgetViewModel: topicsViewModel
         )
         let subject = HomeViewController(viewModel: viewModel)
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/HomeViewControllerTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/HomeViewControllerTests.swift
@@ -29,12 +29,16 @@ struct HomeViewControllerTests {
         Container.shared.analyticsService.register {
             mockAnalyticsService
         }
+        let topicsViewModel = TopicsWidgetViewModel(
+            topicsService: MockTopicsService(),
+            topicAction: { _ in },
+            editAction: { _ in }
+        )
         let viewModel = HomeViewModel(
             configService: MockAppConfigService(),
-            topicsService: MockTopicsService(),
             searchButtonPrimaryAction: { () -> Void in _ = true },
             recentActivityAction: { },
-            topicAction: { _ in }
+            topicWidgetViewModel: topicsViewModel
         )
         let subject = HomeViewController(viewModel: viewModel)
         subject.viewDidAppear(false)

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/HomeViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/HomeViewModelTests.swift
@@ -8,12 +8,16 @@ import Testing
 struct HomeViewModelTests {
     @Test
     func widgets_returnsArrayOfWidgets() {
+        let topicsViewModel = TopicsWidgetViewModel(
+            topicsService: MockTopicsService(),
+            topicAction: { _ in },
+            editAction: { _ in }
+        )
         let subject = HomeViewModel(
             configService: MockAppConfigService(),
-            topicsService: MockTopicsService(),
-            searchButtonPrimaryAction: { },
-            recentActivityAction: {},
-            topicAction: { _ in }
+            searchButtonPrimaryAction: { () -> Void in _ = true },
+            recentActivityAction: { },
+            topicWidgetViewModel: topicsViewModel
         )
         let widgets = subject.widgets
 
@@ -26,12 +30,16 @@ struct HomeViewModelTests {
         let configService = MockAppConfigService()
         configService.features = []
 
+        let topicsViewModel = TopicsWidgetViewModel(
+            topicsService: MockTopicsService(),
+            topicAction: { _ in },
+            editAction: { _ in }
+        )
         let subject = HomeViewModel(
             configService: configService,
-            topicsService: MockTopicsService(),
             searchButtonPrimaryAction: { },
-            recentActivityAction: {},
-            topicAction: { _ in }
+            recentActivityAction: { },
+            topicWidgetViewModel: topicsViewModel
         )
         let widgets = subject.widgets
 

--- a/Tests/govuk_ios/shared/Mocks/Services/MockTopicsService.swift
+++ b/Tests/govuk_ios/shared/Mocks/Services/MockTopicsService.swift
@@ -4,12 +4,14 @@ import Foundation
 
 class MockTopicsService: TopicsServiceInterface {
     
+    let coreData = CoreDataRepository.arrangeAndLoad
+    
     func fetchAllTopics() -> [Topic] {
-        []
+        mockTopics
     }
     
     func fetchFavoriteTopics() -> [Topic] {
-        []
+        mockTopics
     }
     
     var _didUpdateFavoritesCalled = false
@@ -40,5 +42,21 @@ extension MockTopicsService {
     
     static var testTopicsFailure: Result<[TopicResponseItem], TopicsListError> {
         return .failure(.decodingError)
+    }
+    
+    var mockTopics: [Topic] {
+        let result = Self.testTopicsResult
+        var topics = [Topic]()
+        guard let topicResponses = try? result.get() else {
+            return topics
+        }
+        for response in topicResponses {
+            let topic = Topic(context: coreData.viewContext)
+            topic.title = response.title
+            topic.ref = response.ref
+            topic.isFavorite = true
+            topics.append(topic)
+        }
+        return topics
     }
 }

--- a/Tests/govuk_ios/shared/Mocks/Services/MockTopicsService.swift
+++ b/Tests/govuk_ios/shared/Mocks/Services/MockTopicsService.swift
@@ -3,9 +3,25 @@ import Foundation
 @testable import govuk_ios
 
 class MockTopicsService: TopicsServiceInterface {
-    var _receivedFetchTopicsResult: Result<[Topic], TopicsListError>?
-    func fetchTopics(completion: @escaping FetchTopicsListResult) {
+    
+    func fetchAllTopics() -> [Topic] {
+        []
+    }
+    
+    func fetchFavoriteTopics() -> [Topic] {
+        []
+    }
+    
+    var _didUpdateFavoritesCalled = false
+    func updateFavoriteTopics() {
+        _didUpdateFavoritesCalled = true
+    }
+    
+    var _receivedFetchTopicsResult: Result<[TopicResponseItem], TopicsListError>?
+    var _dataReceived = false
+    func downloadTopicsList(completion: @escaping FetchTopicsListResult) {
         if let result = _receivedFetchTopicsResult {
+            _dataReceived = (try? result.get()) != nil
             completion(result)
         } else {
             completion(.failure(.apiUnavailable))
@@ -14,15 +30,15 @@ class MockTopicsService: TopicsServiceInterface {
 }
 
 extension MockTopicsService {
-    static var testTopicsResult: Result<[Topic], TopicsListError> {
-        let topics = [Topic(ref: "driving-transport", title: "Driving & Transport"),
-                      Topic(ref: "care", title: "Care"),
-                      Topic(ref: "business", title: "Business")
+    static var testTopicsResult: Result<[TopicResponseItem], TopicsListError> {
+        let topics = [TopicResponseItem(ref: "driving-transport", title: "Driving & Transport"),
+                      TopicResponseItem(ref: "care", title: "Care"),
+                      TopicResponseItem(ref: "business", title: "Business")
                       ]
         return .success(topics)
     }
     
-    static var testTopicsFailure: Result<[Topic], TopicsListError> {
-        return .failure(.apiUnavailable)
+    static var testTopicsFailure: Result<[TopicResponseItem], TopicsListError> {
+        return .failure(.decodingError)
     }
 }


### PR DESCRIPTION
Added EditTopics page and the ability to select favorite topics to show on Home page
Topic information is now persisted in CoreData after download.   Topics have an 'isFavorite' attribute which 
can be toggled on the EditTopics page
The TopicsWidgetView now depends on CoreData for showing it's list of topics.  As such, it listens for managed object context changes and updates accordingly.

One change worth pointing out is that CoreDataRepository now has a scope of singleton when being used by Factory.  This prevents multiple repos from being created, which I believe was the reason we were seeing errors about non-unique entities. 