### PR TITLE
Fix VO nav order, and scrolling of subtitle

### DIFF
--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -22,6 +22,7 @@ class TopicsWidgetView: UIView {
                          action: #selector(viewModel.didTapEdit),
                          for: .touchUpInside
         )
+        button.accessibilityLabel = String.topics.localized("editTopicsTitle")
         return button
     }()
 
@@ -79,6 +80,7 @@ class TopicsWidgetView: UIView {
     private func configureUI() {
         headerStackView.addArrangedSubview(titleLabel)
         headerStackView.addArrangedSubview(editButton)
+        headerStackView.accessibilityElements = [titleLabel, editButton]
         stackView.addArrangedSubview(headerStackView)
         stackView.addArrangedSubview(cardStackView)
         addSubview(stackView)

--- a/Production/govuk_ios/Views/Topics/EditTopicsView.swift
+++ b/Production/govuk_ios/Views/Topics/EditTopicsView.swift
@@ -5,11 +5,11 @@ struct EditTopicsView: View {
 
     var body: some View {
         VStack {
-            Text(String.topics.localized("editTopicsSubtitle"))
-                .multilineTextAlignment(.leading)
-                .padding(.horizontal, 12)
-                .padding(.top, 10)
             ScrollView {
+                Text(String.topics.localized("editTopicsSubtitle"))
+                    .multilineTextAlignment(.leading)
+                    .padding(.horizontal, 12)
+                    .padding(.top, 10)
                 GroupedList(content: viewModel.sections)
             }
         }


### PR DESCRIPTION
Fix VO to read Topics before Edit button on home page. 
Edit Topics page subtitle now scrolls