### PR TITLE
Use default (opaque) appearance for tab bar

### DIFF
--- a/Production/govuk_ios/Extensions/UIKit/UITabBarAppearance+GOVUK.swift
+++ b/Production/govuk_ios/Extensions/UIKit/UITabBarAppearance+GOVUK.swift
@@ -4,7 +4,6 @@ import UIKit
 extension UITabBarAppearance {
     static var govUK: UITabBarAppearance {
         let appearance = UITabBarAppearance()
-        appearance.configureWithTransparentBackground()
         appearance.shadowColor = UIColor.govUK.strokes.listDivider
         appearance.backgroundColor = UIColor.govUK.fills.surfaceFixedContainer
         appearance.inlineLayoutAppearance = .govUK


### PR DESCRIPTION
Designs call for the tab bar to be opaque.  For whatever reason, configureWithOpaqueAppearance() does work on all screens, but leaving as the default does.