### PR TITLE
GOVUKAPP-739 'About the app' header is cut off when device rotates

### DIFF
--- a/Production/govuk_ios/ViewControllers/SettingsViewController.swift
+++ b/Production/govuk_ios/ViewControllers/SettingsViewController.swift
@@ -51,8 +51,7 @@ class SettingsViewController: BaseViewController,
 
     private func configureUI() {
         scrollview.translatesAutoresizingMaskIntoConstraints = false
-        let contentInsets = UIEdgeInsets(top: 10.0, left: 0.0, bottom: 0.0, right: 0.0)
-        self.scrollview.contentInset = contentInsets
+        self.scrollview.contentInset = UIEdgeInsets(top: 10.0, left: 0.0, bottom: 0.0, right: 0.0)
         scrollview.contentInsetAdjustmentBehavior = .never
         view.addSubview(scrollview)
 

--- a/Production/govuk_ios/ViewControllers/SettingsViewController.swift
+++ b/Production/govuk_ios/ViewControllers/SettingsViewController.swift
@@ -40,23 +40,20 @@ class SettingsViewController: BaseViewController,
         configureConstraints()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.scrollview.setContentOffset(CGPoint(x: 0, y: -16), animated: true)
-    }
-
     override func viewWillTransition(to size: CGSize,
                                      with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         navigationItem.largeTitleDisplayMode = .always
         coordinator.animate(alongsideTransition: { (_) in
             self.navigationController?.navigationBar.sizeToFit()
-            self.scrollview.setContentOffset(CGPoint(x: 0, y: -16), animated: true)
         }, completion: nil)
     }
 
     private func configureUI() {
         scrollview.translatesAutoresizingMaskIntoConstraints = false
+        let contentInsets = UIEdgeInsets(top: 10.0, left: 0.0, bottom: 0.0, right: 0.0)
+        self.scrollview.contentInset = contentInsets
+        scrollview.contentInsetAdjustmentBehavior = .never
         view.addSubview(scrollview)
 
         addChild(contentViewController)
@@ -75,8 +72,7 @@ class SettingsViewController: BaseViewController,
                 equalTo: scrollview.trailingAnchor
             ),
             contentViewController.view.topAnchor.constraint(
-                equalTo: scrollview.contentLayoutGuide.topAnchor,
-                constant: 10
+                equalTo: scrollview.contentLayoutGuide.topAnchor
             ),
             contentViewController.view.heightAnchor.constraint(
                 lessThanOrEqualTo: scrollview.contentLayoutGuide.heightAnchor

--- a/Production/govuk_ios/ViewControllers/SettingsViewController.swift
+++ b/Production/govuk_ios/ViewControllers/SettingsViewController.swift
@@ -40,6 +40,21 @@ class SettingsViewController: BaseViewController,
         configureConstraints()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.scrollview.setContentOffset(CGPoint(x: 0, y: -16), animated: true)
+    }
+
+    override func viewWillTransition(to size: CGSize,
+                                     with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        navigationItem.largeTitleDisplayMode = .always
+        coordinator.animate(alongsideTransition: { (_) in
+            self.navigationController?.navigationBar.sizeToFit()
+            self.scrollview.setContentOffset(CGPoint(x: 0, y: -16), animated: true)
+        }, completion: nil)
+    }
+
     private func configureUI() {
         scrollview.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(scrollview)


### PR DESCRIPTION
There are 2 issues fixed here:

1. Settings title text resizes from large to small when device is rotated from portrait to landscape. When it's rotated back to portrait the Settings title text stays on landscape size (small)

2. The 'About the app' text is cut off at the top after rotating the app from portrait > landscape > portrait AND switching between home and settings tab

[Jira link](https://govukverify.atlassian.net/browse/GOVUKAPP-739) 