### PR TITLE
Remove derived data cache

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,12 +20,6 @@ jobs:
           lfs: 'true'
           fetch-depth: 0
 
-      - name: Cache DerivedData
-        uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # pin@v4.1.1
-        with:
-          path: build_for_unit_testing
-          key: ${{ runner.os }}-${{ github.ref }}-derived-data
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@82dd21cb955e5633e70976c289b2e3b01c0f18db # pin@v1.176.0
         with:


### PR DESCRIPTION
Caching dd corrupts the coverage report for sonar.