### PR TITLE
Add parameter to requests as requiring signature, 

### DIFF
--- a/Production/govuk_ios/Networking/GOVRequest.swift
+++ b/Production/govuk_ios/Networking/GOVRequest.swift
@@ -6,6 +6,7 @@ struct GOVRequest {
     let bodyParameters: [String: Any]?
     let queryParameters: [String: String?]?
     let additionalHeaders: [String: String]?
+    var requiresSignature: Bool = false
 }
 
 enum Method: String {

--- a/Production/govuk_ios/ServiceClients/AppConfigServiceClient.swift
+++ b/Production/govuk_ios/ServiceClients/AppConfigServiceClient.swift
@@ -22,7 +22,8 @@ struct AppConfigServiceClient: AppConfigServiceClientInterface {
             method: .get,
             bodyParameters: nil,
             queryParameters: nil,
-            additionalHeaders: nil
+            additionalHeaders: nil,
+            requiresSignature: true
         )
 
         serviceClient.send(

--- a/Production/govuk_ios/ServiceClients/TopicsServiceClient.swift
+++ b/Production/govuk_ios/ServiceClients/TopicsServiceClient.swift
@@ -28,7 +28,8 @@ struct TopicsServiceClient: TopicsServiceClientInterface {
             method: .get,
             bodyParameters: nil,
             queryParameters: nil,
-            additionalHeaders: nil
+            additionalHeaders: nil,
+            requiresSignature: true
         )
 
         serviceClient.send(
@@ -56,7 +57,8 @@ struct TopicsServiceClient: TopicsServiceClientInterface {
             method: .get,
             bodyParameters: nil,
             queryParameters: nil,
-            additionalHeaders: nil
+            additionalHeaders: nil,
+            requiresSignature: true
         )
 
         serviceClient.send(


### PR DESCRIPTION
and if so, use signature in header to verify data.