### PR TITLE
GOVUKAPP-896:  title wrap when editing, part 2

### DIFF
--- a/Production/govuk_ios/ViewControllers/RecentActivityListViewController.swift
+++ b/Production/govuk_ios/ViewControllers/RecentActivityListViewController.swift
@@ -158,7 +158,6 @@ class RecentActivityListViewController: BaseViewController,
         if !editing {
             viewModel.endEditing()
         }
-        reloadSnapshot()
     }
 
     override func viewDidLayoutSubviews() {

--- a/Production/govuk_ios/Views/Common/GroupedListTableViewCell.swift
+++ b/Production/govuk_ios/Views/Common/GroupedListTableViewCell.swift
@@ -154,6 +154,7 @@ class GroupedListTableViewCell: UITableViewCell {
             accessibilityHint = String.common.localized("openWebLinkHint")
             accessibilityTraits.insert(.link)
         }
+        invalidateIntrinsicContentSize()
     }
 
     override func layoutSubviews() {


### PR DESCRIPTION
call invalidateIntrinsicContentSize() instead of reloading snapshot