### PR TITLE
Onboarding topics

### DIFF
--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		5D54F4752CC84A5B00A3B6A7 /* TopicDetailsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D54F4742CC84A5B00A3B6A7 /* TopicDetailsCoordinator.swift */; };
 		5D6032192C81D68D00C46660 /* Locale+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6032182C81D68D00C46660 /* Locale+Analytics.swift */; };
 		5D62ABC32C32F49F0072BE6C /* Container+Configs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D62ABC22C32F49F0072BE6C /* Container+Configs.swift */; };
+		5D62DC0B2CE6373A0079D842 /* TopicSelectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D62DC0A2CE6373A0079D842 /* TopicSelectedView.swift */; };
 		5D649D332C6BA07800CBED96 /* AnalyticsService+Onboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D649D322C6BA07800CBED96 /* AnalyticsService+Onboarding.swift */; };
 		5D66D1842CBFC12400006723 /* AppEvent+Function.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D66D1832CBFC12400006723 /* AppEvent+Function.swift */; };
 		5D66D1862CBFC13100006723 /* AppEvent+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D66D1852CBFC13100006723 /* AppEvent+Navigation.swift */; };
@@ -353,6 +354,7 @@
 		5D6032182C81D68D00C46660 /* Locale+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Analytics.swift"; sourceTree = "<group>"; };
 		5D62952A2C87429000BBB394 /* GOV.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = GOV.xcdatamodel; sourceTree = "<group>"; };
 		5D62ABC22C32F49F0072BE6C /* Container+Configs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Container+Configs.swift"; sourceTree = "<group>"; };
+		5D62DC0A2CE6373A0079D842 /* TopicSelectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicSelectedView.swift; sourceTree = "<group>"; };
 		5D649D322C6BA07800CBED96 /* AnalyticsService+Onboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsService+Onboarding.swift"; sourceTree = "<group>"; };
 		5D66D1832CBFC12400006723 /* AppEvent+Function.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppEvent+Function.swift"; sourceTree = "<group>"; };
 		5D66D1852CBFC13100006723 /* AppEvent+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppEvent+Navigation.swift"; sourceTree = "<group>"; };
@@ -1219,6 +1221,7 @@
 				4E00EEF02CCB04FF007B61E8 /* TopicOnboardingCard.swift */,
 				4E00EEF22CCB0523007B61E8 /* TopicOnboardingListView.swift */,
 				16D17D412CC01C6A00E99794 /* TopicRowView.swift */,
+				5D62DC0A2CE6373A0079D842 /* TopicSelectedView.swift */,
 				16D0D0422CC6818D00944D79 /* TopicTableViewCell.swift */,
 			);
 			path = Topics;
@@ -1515,6 +1518,7 @@
 				5D349F672C6B548200B7F747 /* RequestBuilder.swift in Sources */,
 				168F6FAA2C4FC56B00A0D7F7 /* RecentActivityWidgetViewModel.swift in Sources */,
 				D028CCF42CB4247100742620 /* TopicsRepository.swift in Sources */,
+				5D62DC0B2CE6373A0079D842 /* TopicSelectedView.swift in Sources */,
 				16F961A72C989165005CFB04 /* SearchResult.swift in Sources */,
 				5DBE080C2C4812ED00B58DBE /* BaseViewController.swift in Sources */,
 				5DBE080E2C49233200B58DBE /* OnboardingService.swift in Sources */,

--- a/Production/govuk_ios/Model/Topics/TopicOnboardingCardModel.swift
+++ b/Production/govuk_ios/Model/Topics/TopicOnboardingCardModel.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-class TopicOnboardingCardModel: ObservableObject {
+class TopicOnboardingCardModel {
     let title: String
     let description: String?
     let iconName: String
     let tapAction: (Bool) -> Void
-    @Published var isSelected: Bool = false
+    var isSelected: Bool = false
 
     init(topic: Topic,
          tapAction: @escaping (Bool) -> Void) {

--- a/Production/govuk_ios/Model/Topics/TopicOnboardingCardModel.swift
+++ b/Production/govuk_ios/Model/Topics/TopicOnboardingCardModel.swift
@@ -1,17 +1,32 @@
 import Foundation
 
-class TopicOnboardingCardModel {
-    let title: String
-    let description: String?
-    let iconName: String
-    let tapAction: (Bool) -> Void
-    var isSelected: Bool = false
+struct TopicOnboardingCardModel {
+    private let topic: Topic
+    private let selectedAction: (Topic) -> Void
 
     init(topic: Topic,
-         tapAction: @escaping (Bool) -> Void) {
-        self.title = topic.title
-        self.description = topic.topicDescription
-        self.iconName = topic.iconName
-        self.tapAction = tapAction
+         selectedAction: @escaping (Topic) -> Void) {
+        self.topic = topic
+        self.selectedAction = selectedAction
+    }
+
+    var title: String {
+        topic.title
+    }
+
+    var description: String? {
+        topic.topicDescription
+    }
+
+    var iconName: String {
+        topic.iconName
+    }
+
+    var isSelected: Bool {
+        topic.isFavorite
+    }
+
+    func selected() {
+        selectedAction(topic)
     }
 }

--- a/Production/govuk_ios/ViewControllers/TopicOnboardingViewController.swift
+++ b/Production/govuk_ios/ViewControllers/TopicOnboardingViewController.swift
@@ -51,10 +51,9 @@ class TopicOnboardingViewController: BaseViewController,
     }()
 
     private lazy var topicsListView = TopicOnboardingListView(
-        selectedAction: { [weak self] topic, selected in
+        selectedAction: { [weak self] topic in
             self?.viewModel.topicSelected(
-                topic: topic,
-                selected: selected
+                topic: topic
             )
         }
     )

--- a/Production/govuk_ios/ViewModels/Topics/TopicOnboardingViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicOnboardingViewModel.swift
@@ -100,6 +100,7 @@ class TopicOnboardingViewModel: ObservableObject {
     }
 
     private func secondaryAction() {
+        topics.first?.managedObjectContext?.rollback()
         trackSecondaryEvent()
         dismissAction()
     }

--- a/Production/govuk_ios/ViewModels/Topics/TopicOnboardingViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicOnboardingViewModel.swift
@@ -5,7 +5,7 @@ class TopicOnboardingViewModel: ObservableObject {
     private let analyticsService: AnalyticsServiceInterface
     private let topicsService: TopicsServiceInterface
     private let dismissAction: () -> Void
-    @Published var isTopicSelected: Bool = false
+    @Published private(set) var isTopicSelected: Bool = false
     private var selectedTopics: Set<Topic> = []
 
     let title = String.topics.localized(
@@ -38,13 +38,15 @@ class TopicOnboardingViewModel: ObservableObject {
     }
 
     private func fetchTopics() {
-        topicsService.fetchRemoteList(completion: { _ in /*Do nothing*/ })
+        topicsService.fetchRemoteList(
+            completion: { _ in /*Do nothing*/ }
+        )
     }
 
-    func topicSelected(topic: Topic,
-                       selected: Bool) {
+    func topicSelected(topic: Topic) {
+        topic.isFavorite.toggle()
         let action: String
-        if selected {
+        if topic.isFavorite {
             action = "add"
             selectedTopics.insert(topic)
         } else {

--- a/Production/govuk_ios/Views/Topics/TopicOnboardingCard.swift
+++ b/Production/govuk_ios/Views/Topics/TopicOnboardingCard.swift
@@ -11,7 +11,6 @@ class TopicOnboardingCard: UIView {
         localView.numberOfLines = 0
         localView.text = viewModel.title
         localView.textAlignment = .center
-        localView.setContentHuggingPriority(.defaultLow, for: .horizontal)
         localView.lineBreakMode = .byWordWrapping
         return localView
     }()
@@ -39,8 +38,6 @@ class TopicOnboardingCard: UIView {
         stackView.axis = .horizontal
         stackView.spacing = 0
         stackView.alignment = .center
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.setContentHuggingPriority(.defaultLow, for: .vertical)
         return stackView
     }()
 
@@ -51,7 +48,6 @@ class TopicOnboardingCard: UIView {
         localView.numberOfLines = 0
         localView.text = viewModel.description
         localView.textAlignment = .center
-        localView.setContentHuggingPriority(.defaultLow, for: .horizontal)
         localView.lineBreakMode = .byWordWrapping
         return localView
     }()
@@ -62,7 +58,6 @@ class TopicOnboardingCard: UIView {
         let imageView = UIImageView(image: image)
         imageView.tintColor = UIColor.govUK.text.link
         imageView.preferredSymbolConfiguration = config
-        imageView.setContentHuggingPriority(.defaultHigh, for: .vertical)
         return imageView
     }()
 
@@ -101,6 +96,9 @@ class TopicOnboardingCard: UIView {
         cardStackView.addArrangedSubview(iconImageView)
         cardStackView.addArrangedSubview(titleLabel)
         cardStackView.addArrangedSubview(descriptionLabel)
+        let spacer = UIView()
+        cardStackView.addArrangedSubview(spacer)
+        cardStackView.setCustomSpacing(0, after: spacer)
         cardStackView.addArrangedSubview(selectedStackView)
         toggleSelectedIconAndTextViews()
     }

--- a/Production/govuk_ios/Views/Topics/TopicOnboardingCard.swift
+++ b/Production/govuk_ios/Views/Topics/TopicOnboardingCard.swift
@@ -108,6 +108,14 @@ class TopicOnboardingCard: UIControl {
         )
     }
 
+    @objc
+    private func cardTapped() {
+        viewModel.selected()
+        toggleTintColorOfCard()
+        selectedStackView.isSelected = viewModel.isSelected
+        configureAccessibility()
+    }
+
     private func configureAccessibility() {
         isAccessibilityElement = true
         accessibilityTraits = .button
@@ -115,15 +123,6 @@ class TopicOnboardingCard: UIControl {
             accessibilityTraits.insert(.selected)
         }
         accessibilityLabel = viewModel.title + ", " + (viewModel.description ?? "")
-    }
-
-    @objc
-    private func cardTapped() {
-        viewModel.isSelected.toggle()
-        toggleTintColorOfCard()
-        viewModel.tapAction(viewModel.isSelected)
-        selectedStackView.isSelected = viewModel.isSelected
-        configureAccessibility()
     }
 
     private func toggleTintColorOfCard() {

--- a/Production/govuk_ios/Views/Topics/TopicOnboardingCard.swift
+++ b/Production/govuk_ios/Views/Topics/TopicOnboardingCard.swift
@@ -1,8 +1,27 @@
 import Foundation
 import UIKit
 
-class TopicOnboardingCard: UIView {
+class TopicOnboardingCard: UIControl {
     private let viewModel: TopicOnboardingCardModel
+
+    private lazy var cardStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 8
+        stackView.alignment = .center
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.isUserInteractionEnabled = false
+        return stackView
+    }()
+
+    private lazy var iconImageView: UIImageView = {
+        let image = UIImage(systemName: viewModel.iconName)
+        let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold)
+        let imageView = UIImageView(image: image)
+        imageView.tintColor = UIColor.govUK.text.link
+        imageView.preferredSymbolConfiguration = config
+        return imageView
+    }()
 
     private lazy var titleLabel: UILabel = {
         let localView = UILabel()
@@ -13,32 +32,6 @@ class TopicOnboardingCard: UIView {
         localView.textAlignment = .center
         localView.lineBreakMode = .byWordWrapping
         return localView
-    }()
-
-    private lazy var selectedLabel: UILabel = {
-        let localView = UILabel()
-        localView.font = .govUK.body
-        localView.text = String.topics.localized(
-            "topicOnboardingCardUnselected"
-        )
-        localView.textAlignment = .center
-        localView.adjustsFontForContentSizeCategory = true
-        localView.numberOfLines = 0
-        return localView
-    }()
-
-    private lazy var selectedIconImageView: UIImageView = {
-        let icon = UIImage(systemName: "plus")
-        let imageView = UIImageView(image: icon)
-        return imageView
-    }()
-
-    private lazy var selectedStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.spacing = 0
-        stackView.alignment = .center
-        return stackView
     }()
 
     private lazy var descriptionLabel: UILabel = {
@@ -52,22 +45,10 @@ class TopicOnboardingCard: UIView {
         return localView
     }()
 
-    private lazy var iconImageView: UIImageView = {
-        let image = UIImage(systemName: viewModel.iconName)
-        let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold)
-        let imageView = UIImageView(image: image)
-        imageView.tintColor = UIColor.govUK.text.link
-        imageView.preferredSymbolConfiguration = config
-        return imageView
-    }()
-
-    private lazy var cardStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.spacing = 8
-        stackView.alignment = .center
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        return stackView
+    private lazy var selectedStackView: TopicSelectedView = {
+        let localView = TopicSelectedView()
+        localView.isSelected = viewModel.isSelected
+        return localView
     }()
 
     init(viewModel: TopicOnboardingCardModel) {
@@ -75,7 +56,7 @@ class TopicOnboardingCard: UIView {
         super.init(frame: .zero)
         configureUI()
         configureConstraints()
-        configureGestures()
+        addActions()
         configureAccessibility()
     }
 
@@ -91,16 +72,15 @@ class TopicOnboardingCard: UIView {
         layer.masksToBounds = true
         layer.borderColor = UIColor.govUK.strokes.listDivider.cgColor
         addSubview(cardStackView)
-        selectedStackView.addArrangedSubview(selectedIconImageView)
-        selectedStackView.addArrangedSubview(selectedLabel)
         cardStackView.addArrangedSubview(iconImageView)
         cardStackView.addArrangedSubview(titleLabel)
         cardStackView.addArrangedSubview(descriptionLabel)
+
         let spacer = UIView()
         cardStackView.addArrangedSubview(spacer)
         cardStackView.setCustomSpacing(0, after: spacer)
+
         cardStackView.addArrangedSubview(selectedStackView)
-        toggleSelectedIconAndTextViews()
     }
 
     private func configureConstraints() {
@@ -120,12 +100,12 @@ class TopicOnboardingCard: UIView {
         ])
     }
 
-    private func configureGestures() {
-        let tapGestureRecognizer = UITapGestureRecognizer(
-            target: self,
-            action: #selector(cardTapped)
+    private func addActions() {
+        addTarget(
+            self,
+            action: #selector(cardTapped),
+            for: .touchUpInside
         )
-        addGestureRecognizer(tapGestureRecognizer)
     }
 
     private func configureAccessibility() {
@@ -141,25 +121,9 @@ class TopicOnboardingCard: UIView {
     private func cardTapped() {
         viewModel.isSelected.toggle()
         toggleTintColorOfCard()
-        toggleSelectedIconAndTextViews()
-        viewModel.tapAction(
-            viewModel.isSelected
-        )
+        viewModel.tapAction(viewModel.isSelected)
+        selectedStackView.isSelected = viewModel.isSelected
         configureAccessibility()
-    }
-
-    private func toggleSelectedIconAndTextViews() {
-        selectedLabel.text = viewModel.isSelected ?
-        String.topics.localized("topicOnboardingCardSelected") :
-        String.topics.localized("topicOnboardingCardUnselected")
-
-        selectedLabel.textColor = viewModel.isSelected ?
-        UIColor.govUK.text.buttonSuccess :
-        UIColor.govUK.text.link
-
-        selectedIconImageView.tintColor = viewModel.isSelected ?
-        UIColor.govUK.text.buttonSuccess :
-        UIColor.govUK.fills.surfaceButtonPrimary
     }
 
     private func toggleTintColorOfCard() {

--- a/Production/govuk_ios/Views/Topics/TopicOnboardingCard.swift
+++ b/Production/govuk_ios/Views/Topics/TopicOnboardingCard.swift
@@ -56,8 +56,9 @@ class TopicOnboardingCard: UIControl {
         super.init(frame: .zero)
         configureUI()
         configureConstraints()
-        addActions()
         configureAccessibility()
+        configureSelectedState()
+        addActions()
     }
 
     required init(coder: NSCoder) {
@@ -81,6 +82,12 @@ class TopicOnboardingCard: UIControl {
         cardStackView.setCustomSpacing(0, after: spacer)
 
         cardStackView.addArrangedSubview(selectedStackView)
+    }
+
+    private func configureSelectedState() {
+        toggleTintColorOfCard()
+        selectedStackView.isSelected = viewModel.isSelected
+        configureAccessibility()
     }
 
     private func configureConstraints() {
@@ -111,9 +118,7 @@ class TopicOnboardingCard: UIControl {
     @objc
     private func cardTapped() {
         viewModel.selected()
-        toggleTintColorOfCard()
-        selectedStackView.isSelected = viewModel.isSelected
-        configureAccessibility()
+        configureSelectedState()
     }
 
     private func configureAccessibility() {

--- a/Production/govuk_ios/Views/Topics/TopicOnboardingListView.swift
+++ b/Production/govuk_ios/Views/Topics/TopicOnboardingListView.swift
@@ -2,13 +2,14 @@ import Foundation
 import UIKit
 
 class TopicOnboardingListView: UIView {
-    private var rowCount = 2
+    private var rowCount: Int {
+        UITraitCollection.current.verticalSizeClass == .regular ? 2 : 4
+    }
 
     private lazy var cardStackView: UIStackView = {
         let localView = UIStackView()
         localView.axis = .vertical
         localView.spacing = 16
-        localView.alignment = .leading
         localView.distribution = .fill
         localView.translatesAutoresizingMaskIntoConstraints = false
         return localView
@@ -49,35 +50,24 @@ class TopicOnboardingListView: UIView {
     }
 
     func updateTopics(_ topics: [Topic]) {
-        let sizeClass = UITraitCollection.current.verticalSizeClass
-        rowCount = sizeClass == .regular ? 2 : 4
         cardStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         for index in 0..<topics.count where index % rowCount == 0 {
             let rowStack = createRow(startingAt: index, of: topics)
-            rowStack.translatesAutoresizingMaskIntoConstraints = false
             cardStackView.addArrangedSubview(rowStack)
-            rowStack.leadingAnchor.constraint(
-                equalTo: cardStackView.leadingAnchor
-            ).isActive = true
-            rowStack.trailingAnchor.constraint(
-                equalTo: cardStackView.trailingAnchor
-            ).isActive = true
         }
     }
 
     private func createRow(startingAt startIndex: Int,
                            of topics: [Topic]) -> UIStackView {
         let rowStack = createRowStack()
-        let firstCard = createOnboardingTopicCard(for: topics[startIndex])
-        rowStack.addArrangedSubview(firstCard)
-
-        for index in (startIndex + 1)..<(startIndex + rowCount) {
+        for index in startIndex..<(startIndex + rowCount) {
+            let view: UIView
             if index <= topics.count - 1 {
-                let card = createOnboardingTopicCard(for: topics[index])
-                rowStack.addArrangedSubview(card)
+                view = createOnboardingTopicCard(for: topics[index])
             } else {
-                rowStack.addArrangedSubview(UIView())
+                view = UIView()
             }
+            rowStack.addArrangedSubview(view)
         }
         return rowStack
     }

--- a/Production/govuk_ios/Views/Topics/TopicOnboardingListView.swift
+++ b/Production/govuk_ios/Views/Topics/TopicOnboardingListView.swift
@@ -61,12 +61,9 @@ class TopicOnboardingListView: UIView {
                            of topics: [Topic]) -> UIStackView {
         let rowStack = createRowStack()
         for index in startIndex..<(startIndex + rowCount) {
-            let view: UIView
-            if index <= topics.count - 1 {
-                view = createOnboardingTopicCard(for: topics[index])
-            } else {
-                view = UIView()
-            }
+            let view = index <= topics.count - 1 ?
+            createOnboardingTopicCard(for: topics[index]) :
+            UIView()
             rowStack.addArrangedSubview(view)
         }
         return rowStack

--- a/Production/govuk_ios/Views/Topics/TopicOnboardingListView.swift
+++ b/Production/govuk_ios/Views/Topics/TopicOnboardingListView.swift
@@ -75,7 +75,6 @@ class TopicOnboardingListView: UIView {
             if index <= topics.count - 1 {
                 let card = createOnboardingTopicCard(for: topics[index])
                 rowStack.addArrangedSubview(card)
-                firstCard.heightAnchor.constraint(equalTo: card.heightAnchor).isActive = true
             } else {
                 rowStack.addArrangedSubview(UIView())
             }

--- a/Production/govuk_ios/Views/Topics/TopicOnboardingListView.swift
+++ b/Production/govuk_ios/Views/Topics/TopicOnboardingListView.swift
@@ -14,9 +14,9 @@ class TopicOnboardingListView: UIView {
         return localView
     }()
 
-    private var selectedAction: (Topic, Bool) -> Void
+    private var selectedAction: (Topic) -> Void
 
-    init(selectedAction: @escaping (Topic, Bool) -> Void) {
+    init(selectedAction: @escaping (Topic) -> Void) {
         self.selectedAction = selectedAction
         super.init(frame: .zero)
         configureUI()
@@ -93,12 +93,8 @@ class TopicOnboardingListView: UIView {
     private func createOnboardingTopicCard(for topic: Topic) -> TopicOnboardingCard {
         let model = TopicOnboardingCardModel(
             topic: topic,
-            tapAction: { [weak self] isSelected in
-                self?.selectedAction(topic, isSelected)
-            }
+            selectedAction: selectedAction
         )
-        let topicCard = TopicOnboardingCard(viewModel: model)
-        topicCard.translatesAutoresizingMaskIntoConstraints = false
-        return topicCard
+        return TopicOnboardingCard(viewModel: model)
     }
 }

--- a/Production/govuk_ios/Views/Topics/TopicSelectedView.swift
+++ b/Production/govuk_ios/Views/Topics/TopicSelectedView.swift
@@ -1,0 +1,59 @@
+import Foundation
+import UIKit
+
+class TopicSelectedView: UIStackView {
+    private lazy var selectedIconImageView: UIImageView = {
+        let icon = UIImage(systemName: "plus")
+        let imageView = UIImageView(image: icon)
+        return imageView
+    }()
+
+    private lazy var selectedLabel: UILabel = {
+        let localView = UILabel()
+        localView.font = .govUK.body
+        localView.text = String.topics.localized(
+            "topicOnboardingCardUnselected"
+        )
+        localView.textAlignment = .center
+        localView.adjustsFontForContentSizeCategory = true
+        localView.numberOfLines = 0
+        return localView
+    }()
+
+    var isSelected: Bool = false {
+        didSet {
+            toggleSelectedIconAndTextViews()
+        }
+    }
+
+    init() {
+        super.init(frame: .zero)
+        configureUI()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configureUI() {
+        axis = .horizontal
+        spacing = 0
+        alignment = .center
+        addArrangedSubview(selectedIconImageView)
+        addArrangedSubview(selectedLabel)
+    }
+
+    private func toggleSelectedIconAndTextViews() {
+        selectedLabel.text = isSelected ?
+        String.topics.localized("topicOnboardingCardSelected") :
+        String.topics.localized("topicOnboardingCardUnselected")
+
+        selectedLabel.textColor = isSelected ?
+        UIColor.govUK.text.buttonSuccess :
+        UIColor.govUK.text.link
+
+        selectedIconImageView.tintColor = isSelected ?
+        UIColor.govUK.text.buttonSuccess :
+        UIColor.govUK.fills.surfaceButtonPrimary
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f84ac6fd9612ea9ba0c9977f7f2d4030de0cca3186e956649f2173a49871bf9a
-size 164367
+oid sha256:89d92abd0a9ebb082589f0b3e482ace26c5031b093cf643c144dafbb7f5ad657
+size 276

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89d92abd0a9ebb082589f0b3e482ace26c5031b093cf643c144dafbb7f5ad657
-size 276
+oid sha256:f84ac6fd9612ea9ba0c9977f7f2d4030de0cca3186e956649f2173a49871bf9a
+size 164367

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3ea8ce65101915dfb657cb093e91ef079400ea076102bc836934778473e827f
-size 155689
+oid sha256:f84ac6fd9612ea9ba0c9977f7f2d4030de0cca3186e956649f2173a49871bf9a
+size 164367

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:166cdebb1a04f345e8203981d2a1644c556811ba0e4efbe85a6a5b2dbc59e4b1
-size 153889
+oid sha256:72842a0e3fd2d8251bea4d782fc8c16ef9791b025edb77d96056e30714827ed5
+size 163831

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72842a0e3fd2d8251bea4d782fc8c16ef9791b025edb77d96056e30714827ed5
-size 163831
+oid sha256:ffc73c6395e8cb9367c0b39f4232896a7e75cc8878699545f43fb8b2ff837bd9
+size 276

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.TopicOnboardingViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffc73c6395e8cb9367c0b39f4232896a7e75cc8878699545f43fb8b2ff837bd9
-size 276
+oid sha256:72842a0e3fd2d8251bea4d782fc8c16ef9791b025edb77d96056e30714827ed5
+size 163831


### PR DESCRIPTION
PR updates the way the topics are selected in onoarding.
We now set it on the topic object and then roll back the MOC should the user press "Skip." This approach is still up for debate, and I have a spike planned to test a couple of alternative approaches at some point.
The PR also fixes some layout issues in the layout of the cards.