### PR TITLE
Remove signature from AppConfig

### DIFF
--- a/Production/govuk_ios/Model/AppConfig/AppConfig.swift
+++ b/Production/govuk_ios/Model/AppConfig/AppConfig.swift
@@ -3,5 +3,4 @@ import Foundation
 struct AppConfig: Decodable {
     let platform: String
     let config: Config
-    let signature: String
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Arrangers/Model/AppConfig+Arrangers.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Arrangers/Model/AppConfig+Arrangers.swift
@@ -8,12 +8,10 @@ extension AppConfig {
     }
 
     static func arrange(platform: String = "iOS",
-                        config: Config = .arrange,
-                        signature: String = "") -> AppConfig {
+                        config: Config = .arrange) -> AppConfig {
         .init(
             platform: platform,
-            config: config,
-            signature: signature
+            config: config
         )
     }
 }


### PR DESCRIPTION
The signature is to no longer be passed as part of the response body, as we get it from the headers now.
Remove the "signature" parameter to insure responses are parsed correctly when the change is pushed on the back end