### PR TITLE
GOVUKAPP-974:  edit topics button accessibility size change

### DIFF
--- a/Production/govuk_ios/Extensions/UIKit/UIButton+Convenience.swift
+++ b/Production/govuk_ios/Extensions/UIKit/UIButton+Convenience.swift
@@ -8,6 +8,7 @@ extension UIButton {
         let button = UIButton(type: .system)
         button.setTitle(title, for: .normal)
         button.titleLabel?.font = UIFont.govUK.body
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.addAction(
             .init(handler: { _ in action() }),
             for: .touchUpInside

--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -180,6 +180,15 @@ class TopicsWidgetView: UIView {
             rowCount = sizeClass == .regular ? 2 : 4
             updateTopics(viewModel.displayedTopics)
         }
+
+        // At largest size, will truncate titleLabel text so edit button remains visible
+        // At smaller sizes, ensures edit button remains right-aligned
+        if UITraitCollection.current.preferredContentSizeCategory
+            == .accessibilityExtraExtraExtraLarge {
+            titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        } else {
+            titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        }
     }
 
     private func showAllTopicsButton() {


### PR DESCRIPTION
Make sure edit button label adjusts size on accessibility change.
Adjust titleLabel compression on largest font size so Edit button remains visible