### PR TITLE
Govukapp-865 ios home button behavior

### DIFF
--- a/Production/govuk_ios/Coordinators/BaseCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/BaseCoordinator.swift
@@ -4,7 +4,7 @@ import UIKit
 class BaseCoordinator: NSObject,
                        UINavigationControllerDelegate,
                        UIAdaptivePresentationControllerDelegate {
-    private var childCoordinators: [BaseCoordinator] = []
+    private(set) var childCoordinators: [BaseCoordinator] = []
     private var parentCoordinator: BaseCoordinator?
     private var stackedViewControllers: NSHashTable<UIViewController> = .weakObjects()
     private(set) var root: UINavigationController

--- a/Production/govuk_ios/Coordinators/EditTopicsCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/EditTopicsCoordinator.swift
@@ -33,7 +33,7 @@ final class EditTopicsCoordinator: BaseCoordinator {
         root.dismiss(
             animated: true,
             completion: { [weak self] in
-                self?.dismissed()
+                self?.finish()
             }
         )
     }

--- a/Production/govuk_ios/Coordinators/HomeCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/HomeCoordinator.swift
@@ -43,6 +43,14 @@ class HomeCoordinator: TabItemCoordinator {
         )
     }
 
+    func didReselectTab() {
+        guard let homeViewController = root.viewControllers.first as? HomeViewController
+        else {
+            return
+        }
+        homeViewController.scrollToTop()
+    }
+
     private var presentSearchCoordinator: () -> Void {
         return { [weak self] in
             self?.trackWidgetNavigation(text: "Search")

--- a/Production/govuk_ios/Coordinators/HomeCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/HomeCoordinator.swift
@@ -44,11 +44,13 @@ class HomeCoordinator: TabItemCoordinator {
     }
 
     func didReselectTab() {
-        guard let homeViewController = root.viewControllers.first as? HomeViewController
+        guard let homeViewController = root.viewControllers.first as? ContentScrollable
         else {
             return
         }
-        homeViewController.scrollToTop()
+        if childCoordinators.isEmpty {
+            homeViewController.scrollToTop()
+        }
     }
 
     private var presentSearchCoordinator: () -> Void {

--- a/Production/govuk_ios/Coordinators/SettingsCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/SettingsCoordinator.swift
@@ -32,4 +32,6 @@ class SettingsCoordinator: TabItemCoordinator {
             parent: self
         )
     }
+
+    func didReselectTab() { /*protocol conformance*/ }
 }

--- a/Production/govuk_ios/Coordinators/TabCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/TabCoordinator.swift
@@ -1,12 +1,19 @@
 import UIKit
 import Foundation
 
-typealias TabItemCoordinator = BaseCoordinator & DeeplinkRouteProvider
+typealias TabItemCoordinator = BaseCoordinator
+& DeeplinkRouteProvider
+& TabItemCoordinatorInterface
+
+protocol TabItemCoordinatorInterface {
+    func didReselectTab()
+}
 
 class TabCoordinator: BaseCoordinator,
                       UITabBarControllerDelegate {
     private lazy var homeCoordinator = coordinatorBuilder.home
     private lazy var settingsCoordinator = coordinatorBuilder.settings
+    private var currentTabIndex = 0
 
     private var coordinators: [TabItemCoordinator] {
         [
@@ -74,5 +81,9 @@ class TabCoordinator: BaseCoordinator,
         guard let title = viewController.tabBarItem.title else { return }
         let event = AppEvent.tabNavigation(text: title)
         analyticsService.track(event: event)
+        if currentTabIndex == tabBarController.selectedIndex {
+            coordinators[currentTabIndex].didReselectTab()
+        }
+        currentTabIndex = tabBarController.selectedIndex
     }
 }

--- a/Production/govuk_ios/Extensions/UIKit/UIViewController+Extensions.swift
+++ b/Production/govuk_ios/Extensions/UIKit/UIViewController+Extensions.swift
@@ -1,6 +1,10 @@
 import Foundation
 import UIKit
 
+protocol ContentScrollable {
+    func scrollToTop()
+}
+
 extension UIViewController {
     func viewWillReAppear(isAppearing: Bool = true,
                           animated: Bool = false) {

--- a/Production/govuk_ios/ViewControllers/HomeViewController.swift
+++ b/Production/govuk_ios/ViewControllers/HomeViewController.swift
@@ -81,6 +81,15 @@ class HomeViewController: BaseViewController,
         navigationBar.handleScroll(scrollView: scrollView)
     }
 
+    func scrollToTop() {
+        scrollView.setContentOffset(
+            CGPoint(
+                x: 0,
+                y: -(navigationBar.sittingHeight + 16)
+            ),
+            animated: true)
+    }
+
     private func addWidgets() {
         viewModel.widgets.lazy.forEach(stackView.addArrangedSubview)
     }

--- a/Production/govuk_ios/ViewControllers/HomeViewController.swift
+++ b/Production/govuk_ios/ViewControllers/HomeViewController.swift
@@ -81,15 +81,6 @@ class HomeViewController: BaseViewController,
         navigationBar.handleScroll(scrollView: scrollView)
     }
 
-    func scrollToTop() {
-        scrollView.setContentOffset(
-            CGPoint(
-                x: 0,
-                y: -(navigationBar.sittingHeight + 16)
-            ),
-            animated: true)
-    }
-
     private func addWidgets() {
         viewModel.widgets.lazy.forEach(stackView.addArrangedSubview)
     }
@@ -102,4 +93,15 @@ class HomeViewController: BaseViewController,
 extension HomeViewController: TrackableScreen {
     var trackingName: String { "Homepage" }
     var trackingTitle: String? { "Homepage" }
+}
+
+extension HomeViewController: ContentScrollable {
+    func scrollToTop() {
+        scrollView.setContentOffset(
+            CGPoint(
+                x: 0,
+                y: -(navigationBar.sittingHeight + 16)
+            ),
+            animated: true)
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
@@ -81,11 +81,11 @@ class MockViewControllerBuilder: ViewControllerBuilder {
     }
     
     var _stubbedEditTopicsViewController: UIViewController?
-    var _receivedDoneButtonAction: (() -> Void)?
+    var _receivedDismissAction: (() -> Void)?
     override func editTopics(analyticsService: any AnalyticsServiceInterface,
                              topicsService: any TopicsServiceInterface,
                              dismissAction: @escaping () -> Void) -> UIViewController {
-        _receivedDoneButtonAction = dismissAction
+        _receivedDismissAction = dismissAction
         return _stubbedEditTopicsViewController ?? UIViewController()
     }
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Coordinators/MockBaseCoordinator.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Coordinators/MockBaseCoordinator.swift
@@ -16,9 +16,11 @@ class MockBaseCoordinator: BaseCoordinator,
     }
 
     var _childDidFinishHandler: ((BaseCoordinator) -> Void)?
+    var _childDidFinishReceivedChild: BaseCoordinator??
     override func childDidFinish(_ child: BaseCoordinator) {
         super.childDidFinish(child)
         _childDidFinishHandler?(child)
+        _childDidFinishReceivedChild = child
     }
     
     var _stubbedRoute: ResolvedDeeplinkRoute?

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Coordinators/MockBaseCoordinator.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Coordinators/MockBaseCoordinator.swift
@@ -4,8 +4,8 @@ import Foundation
 @testable import govuk_ios
 
 class MockBaseCoordinator: BaseCoordinator,
-                           DeeplinkRouteProvider {
-
+                           DeeplinkRouteProvider,
+                           TabItemCoordinatorInterface {
     convenience init() {
         self.init(navigationController: .init())
     }
@@ -25,5 +25,9 @@ class MockBaseCoordinator: BaseCoordinator,
     func route(for: URL) -> ResolvedDeeplinkRoute? {
         _stubbedRoute
     }
-
+    
+    var _didReselectTab = false
+    func didReselectTab() {
+        _didReselectTab = true
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/ViewControllers/MockHomeViewController.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/ViewControllers/MockHomeViewController.swift
@@ -1,0 +1,15 @@
+import UIKit
+@testable import govuk_ios
+
+class MockHomeViewController: UIViewController,
+                              ContentScrollable {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    var _didScrollToTop = false
+    func scrollToTop() {
+        _didScrollToTop = true
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/EditTopicsCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/EditTopicsCoordinatorTests.swift
@@ -36,6 +36,7 @@ struct EditTopicsCoordinatorTests {
         let mockTopicsService = MockTopicsService()
         let expectedViewController = UIViewController()
         let navigationController = UINavigationController()
+        let mockCoordinator = MockBaseCoordinator()
 
         mockViewControllerBuilder._stubbedEditTopicsViewController = expectedViewController
 
@@ -49,7 +50,7 @@ struct EditTopicsCoordinatorTests {
                     continuation.resume(returning: true)
                 }
             )
-            subject.start()
+            mockCoordinator.start(subject)
 
             subject.presentationControllerDidDismiss(subject.root.presentationController!)
         }
@@ -64,11 +65,12 @@ struct EditTopicsCoordinatorTests {
         let mockTopicsService = MockTopicsService()
         let expectedViewController = UIViewController()
         let mockNavigationController = MockNavigationController()
+        let mockCoordinator = MockBaseCoordinator()
 
         mockViewControllerBuilder._stubbedEditTopicsViewController = expectedViewController
-
-        _ = await withCheckedContinuation { continuation in
-            let subject = EditTopicsCoordinator(
+        var subject: EditTopicsCoordinator!
+        let dismissed = await withCheckedContinuation { continuation in
+            subject = EditTopicsCoordinator(
                 navigationController: mockNavigationController,
                 analyticsService: mockAnalyticsService,
                 topicsService: mockTopicsService,
@@ -77,12 +79,15 @@ struct EditTopicsCoordinatorTests {
                     continuation.resume(returning: true)
                 }
             )
-            subject.start()
-            
+            mockCoordinator.start(subject)
+
             //Simulate view controller calling close
-            mockViewControllerBuilder._receivedDoneButtonAction?()
+            mockViewControllerBuilder._receivedDismissAction?()
         }
 
+        #expect(dismissed)
+        #expect(mockCoordinator._childDidFinishReceivedChild == subject)
+        #expect(subject != nil)
         #expect(mockNavigationController._dismissCalled)
         #expect(mockNavigationController._receivedDismissAnimated == true)
     }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/HomeCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/HomeCoordinatorTests.swift
@@ -176,4 +176,57 @@ struct HomeCoordinatorTests {
         #expect(navigationEvent?.params?["type"] as? String == "Widget")
         #expect(navigationEvent?.name == "Navigation")
     }
+    
+    @Test
+    @MainActor
+    func didReselectTab_scrollsToTop_whenOnHomeScreen() {
+        let mockCoodinatorBuilder = MockCoordinatorBuilder(container: .init())
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let navigationController = UINavigationController()
+        
+        let homeViewController = MockHomeViewController()
+        mockViewControllerBuilder._stubbedHomeViewController = homeViewController
+        
+        let subject = HomeCoordinator(
+            navigationController: navigationController,
+            coordinatorBuilder: mockCoodinatorBuilder,
+            viewControllerBuilder: mockViewControllerBuilder,
+            deeplinkStore: DeeplinkDataStore(routes: []),
+            analyticsService: MockAnalyticsService(),
+            configService: MockAppConfigService(),
+            topicsService: MockTopicsService()
+        )
+        
+        subject.start()
+        subject.didReselectTab()
+        
+        #expect(homeViewController._didScrollToTop)
+    }
+    
+    @Test
+    @MainActor
+    func didReselectTab_doesNotScrollsToTop_whenOnChildScreen() {
+        let mockCoodinatorBuilder = MockCoordinatorBuilder(container: .init())
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let navigationController = UINavigationController()
+        
+        let homeViewController = MockHomeViewController()
+        mockViewControllerBuilder._stubbedHomeViewController = homeViewController
+        
+        let subject = HomeCoordinator(
+            navigationController: navigationController,
+            coordinatorBuilder: mockCoodinatorBuilder,
+            viewControllerBuilder: mockViewControllerBuilder,
+            deeplinkStore: DeeplinkDataStore(routes: []),
+            analyticsService: MockAnalyticsService(),
+            configService: MockAppConfigService(),
+            topicsService: MockTopicsService()
+        )
+        
+        subject.start()
+        subject.start(MockBaseCoordinator())
+        subject.didReselectTab()
+        
+        #expect(homeViewController._didScrollToTop == false)
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/TabCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/TabCoordinatorTests.swift
@@ -165,4 +165,43 @@ struct TabCoordinatorTests {
 
         #expect(mockAnalyticsService._trackedEvents.count == 0)
     }
+
+    @Test(arguments: zip(
+        [0,1],
+        [true, false]
+    ))
+    func selectingTab_doesCall_didReselectTab_asNeeded(selectedIndex: Int,
+                                                       didReselectTab: Bool) async throws {
+        let mockAnalyticsService = MockAnalyticsService()
+        let mockCoordinatorBuilder = MockCoordinatorBuilder.mock
+
+        let mockHomeCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedHomeCoordinator = mockHomeCoordinator
+
+        let mockSettingsCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedSettingsCoordinator = mockSettingsCoordinator
+
+        let navigationController = UINavigationController()
+        let subject = TabCoordinator(
+            coordinatorBuilder: mockCoordinatorBuilder,
+            navigationController: navigationController,
+            analyticsService: mockAnalyticsService
+        )
+
+        let url = URL(string: "govuk://gov.uk/unknown")
+        subject.start(url: url)
+
+        let tabController = try #require(navigationController.viewControllers.first as? UITabBarController)
+        tabController.selectedIndex = selectedIndex
+
+        let viewController = UIViewController()
+        viewController.tabBarItem = .init(
+            title: "test_title",
+            image: nil,
+            tag: 0
+        )
+        subject.tabBarController(tabController, didSelect: viewController)
+
+        #expect(mockHomeCoordinator._didReselectTab == didReselectTab)
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/HomeViewControllerTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/HomeViewControllerTests.swift
@@ -56,4 +56,30 @@ struct HomeViewControllerTests {
         #expect(screens.first?.trackingClass == subject.trackingClass)
         #expect(screens.first?.additionalParameters.count == 0)
     }
+    
+    @Test
+    func scrollToTop_scrollsContentToTop() {
+        let topicsViewModel = TopicsWidgetViewModel(
+            topicsService: MockTopicsService(),
+            topicAction: { _ in },
+            editAction: { },
+            allTopicsAction: { }
+        )
+        let viewModel = HomeViewModel(
+            analyticsService: MockAnalyticsService(),
+            configService: MockAppConfigService(),
+            topicWidgetViewModel: topicsViewModel,
+            searchAction: { () -> Void in _ = true },
+            recentActivityAction: { }
+        )
+        let subject = HomeViewController(viewModel: viewModel)
+        guard let scrollView: UIScrollView =
+                subject.view.subviews.first(where: { $0 is UIScrollView } ) as? UIScrollView
+        else {
+            return
+        }
+        scrollView.setContentOffset(CGPoint(x: 0, y: 100), animated: false)
+        subject.scrollToTop()
+        #expect(scrollView.contentOffset.y == -72)
+    }
 }


### PR DESCRIPTION
Added TabItemCoordinatorInterface protocol, defining a method to invoke when an already selected tab is reselected.
All TabItemCoordinators now implement this protocol
This allows HomeCoordinator to invoke scroll to top on HomeViewController when the home tab is reselected.