### PR TITLE
GOVUKAPP-838 Prevent CoreData backup

### DIFF
--- a/Production/govuk_ios/Extensions/Container/Container+DataStores.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+DataStores.swift
@@ -1,11 +1,29 @@
 import Foundation
 import Factory
+import CoreData
 
 extension Container {
+    var coreDataModel: Factory<NSManagedObjectModel> {
+        Factory(self) {
+            let url = Bundle.main.url(
+                forResource: "GOV",
+                withExtension: "momd"
+            )!
+            return NSManagedObjectModel(
+                contentsOf: url
+            )!
+        }
+        .scope(.singleton)
+    }
+
     var coreDataRepository: Factory<CoreDataRepositoryInterface> {
         Factory(self) {
-            CoreDataRepository(
-                persistentContainer: .init(name: "GOV"),
+            let container = NSPersistentContainer(
+                name: "GOV",
+                managedObjectModel: self.coreDataModel.resolve()
+            )
+            return CoreDataRepository(
+                persistentContainer: container,
                 notificationCenter: .default
             ).load()
         }

--- a/Production/govuk_ios/Repositories/CoreDataRepository.swift
+++ b/Production/govuk_ios/Repositories/CoreDataRepository.swift
@@ -20,15 +20,23 @@ class CoreDataRepository: CoreDataRepositoryInterface {
 
     func load() -> Self {
         persistentContainer.loadPersistentStores(
-            completionHandler: { _, error in
+            completionHandler: { [weak self] description, error in
                 if let error = error {
                     fatalError("Unable to load persistent stores: \(error)")
                 }
+                self?.excludeStoreFromiTunesBackup(url: description.url)
             }
         )
         addBackgroundObserver()
         addViewObserver()
         return self
+    }
+
+    private func excludeStoreFromiTunesBackup(url: URL?) {
+        guard var url = url else { return }
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        try? url.setResourceValues(resourceValues)
     }
 
     private(set) lazy var viewContext: NSManagedObjectContext = {

--- a/Tests/govuk_ios/shared/Arrangers/Repositories/CoreDataRepository+Arrangers.swift
+++ b/Tests/govuk_ios/shared/Arrangers/Repositories/CoreDataRepository+Arrangers.swift
@@ -1,17 +1,10 @@
 import Foundation
 import CoreData
+import Factory
 
 @testable import govuk_ios
 
 extension CoreDataRepository {
-    static var model: NSManagedObjectModel = {
-        let url = Bundle.main.url(
-            forResource: "GOV",
-            withExtension: "momd"
-        )!
-        return NSManagedObjectModel(contentsOf: url)!
-    }()
-
     static var arrangeAndLoad: CoreDataRepository {
         arrange().load()
     }
@@ -23,9 +16,10 @@ extension CoreDataRepository {
     static func arrange(notificationCenter: NotificationCenter = .default) -> CoreDataRepository {
         let container = NSPersistentContainer(
             name: "GOV",
-            managedObjectModel: model
+            managedObjectModel: Container.shared.coreDataModel.resolve()
         )
         let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
         description.url = URL(fileURLWithPath: "/dev/null")
         container.persistentStoreDescriptions = [description]
         return .init(


### PR DESCRIPTION
Moved core data model to Container to prevent warnings during unit testing. This is not ideal, if we manage to prevent the app launching a real DB during unit tests, we can remove this.
When the persistent stores are loaded, we use the completion handler with the description to "snatch" the store's URL and mark it as excluded from backup.
Should this not work 100% of the time, we might want to expose a method and call it when the app enters background or similar. 