### PR TITLE
Adds trailing padding to grouped section icon header

### DIFF
--- a/Production/govuk_ios/SwiftUIViews/GroupedList/GroupedListSectionIconView.swift
+++ b/Production/govuk_ios/SwiftUIViews/GroupedList/GroupedListSectionIconView.swift
@@ -18,6 +18,7 @@ struct GroupedListSectionIconView: View {
                             .foregroundColor(Color(UIColor.govUK.text.primary))
                             .accessibilityAddTraits(.isHeader)
                             .padding(.leading, 8)
+                            .padding(.trailing, 16)
                             .padding(.vertical, 16)
                             .fixedSize(horizontal: false, vertical: true)
                     }


### PR DESCRIPTION
The text can squash up against the trailing border for a given text size when adjusting dynamic type.