### PR TITLE
[GOVUKAPP-1074] Add analytics for history + suggestions

### DIFF
--- a/Production/govuk_ios/Extensions/Analytics/AppEvent+Search.swift
+++ b/Production/govuk_ios/Extensions/Analytics/AppEvent+Search.swift
@@ -13,10 +13,11 @@ extension AppEvent {
         )
     }
 
-    static func searchTerm(term: String) -> AppEvent {
+    static func searchTerm(term: String, type: SearchInvocationType) -> AppEvent {
         search(
             params: [
-                "text": term
+                "text": term,
+                "type": type.rawValue
             ]
         )
     }

--- a/Production/govuk_ios/ViewModels/SearchViewModel.swift
+++ b/Production/govuk_ios/ViewModels/SearchViewModel.swift
@@ -41,13 +41,14 @@ class SearchViewModel {
     }
 
     func search(text: String?,
+                type: SearchInvocationType,
                 completion: @escaping () -> Void) {
         error = nil
         guard let text = text,
               !text.isEmpty
         else { return }
 
-        trackSearchTerm(searchTerm: text)
+        trackSearchTerm(searchTerm: text, type: type)
         searchService.search(
             text,
             completion: { [weak self] result in
@@ -78,11 +79,14 @@ class SearchViewModel {
         )
     }
 
-    private func trackSearchTerm(searchTerm: String) {
+    private func trackSearchTerm(searchTerm: String, type: SearchInvocationType) {
         let redactor = Redactor.pii
         let redactedSearchTerm = redactor.redact(searchTerm)
         analyticsService.track(
-            event: AppEvent.searchTerm(term: redactedSearchTerm)
+            event: AppEvent.searchTerm(
+                term: redactedSearchTerm,
+                type: type
+            )
         )
     }
 }

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SearchViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SearchViewControllerSnapshotTests.swift
@@ -33,8 +33,10 @@ class SearchViewControllerSnapshotTests: SnapshotTestCase {
         let viewController = createViewController(result: .success(result))
         viewController.viewDidLoad()
         let searchBar = viewController.view.subviews.compactMap { $0 as? UISearchBar }.first
-        searchBar?.searchTextField.text = "Test with results"
-        searchBar?.searchTextField.sendActions(for: .editingDidEndOnExit)
+        let textField = searchBar!.searchTextField
+        textField.text = "Test with results"
+        let _ = viewController.textFieldShouldReturn(textField)
+
         VerifySnapshotInNavigationController(
             viewController: viewController,
             mode: .light
@@ -45,8 +47,9 @@ class SearchViewControllerSnapshotTests: SnapshotTestCase {
         let viewController = createViewController(result: .failure(.noResults))
         viewController.viewDidLoad()
         let searchBar = viewController.view.subviews.compactMap { $0 as? UISearchBar }.first
-        searchBar?.searchTextField.text = "Empty results"
-        searchBar?.searchTextField.sendActions(for: .editingDidEndOnExit)
+        let textField = searchBar!.searchTextField
+        textField.text = "Empty results"
+        let _ = viewController.textFieldShouldReturn(textField)
         viewController.view.layoutSubviews()
         VerifySnapshotInNavigationController(
             viewController: viewController,
@@ -58,8 +61,9 @@ class SearchViewControllerSnapshotTests: SnapshotTestCase {
         let viewController = createViewController(result: .failure(.apiUnavailable))
         viewController.viewDidLoad()
         let searchBar = viewController.view.subviews.compactMap { $0 as? UISearchBar }.first
-        searchBar?.searchTextField.text = "Generic error"
-        searchBar?.searchTextField.sendActions(for: .editingDidEndOnExit)
+        let textField = searchBar!.searchTextField
+        textField.text = "Generic error"
+        let _ = viewController.textFieldShouldReturn(textField)
         viewController.view.layoutSubviews()
         VerifySnapshotInNavigationController(
             viewController: viewController,
@@ -71,8 +75,9 @@ class SearchViewControllerSnapshotTests: SnapshotTestCase {
         let viewController = createViewController(result: .failure(.networkUnavailable))
         viewController.viewDidLoad()
         let searchBar = viewController.view.subviews.compactMap { $0 as? UISearchBar }.first
-        searchBar?.searchTextField.text = "Network unavailable"
-        searchBar?.searchTextField.sendActions(for: .editingDidEndOnExit)
+        let textField = searchBar!.searchTextField
+        textField.text = "Network unavailable"
+        let _ = viewController.textFieldShouldReturn(textField)
         viewController.view.layoutSubviews()
         VerifySnapshotInNavigationController(
             viewController: viewController,

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Extensions/Analytics/AppEvent+SearchTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Extensions/Analytics/AppEvent+SearchTests.swift
@@ -32,11 +32,15 @@ struct AppEvent_SearchTests {
     @Test
     func searchTerm_returnsExpectedResult() {
         let expectedTerm = UUID().uuidString
-        let result = AppEvent.searchTerm(term: expectedTerm)
+        let result = AppEvent.searchTerm(
+            term: expectedTerm,
+            type: .typed
+        )
 
         #expect(result.name == "Search")
-        #expect(result.params?.count == 1)
+        #expect(result.params?.count == 2)
         #expect(result.params?["text"] as? String == expectedTerm)
+        #expect(result.params?["type"] as? String == "typed")
     }
 
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/SearchViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/SearchViewModelTests.swift
@@ -74,6 +74,7 @@ struct SearchViewModelTests{
 
         subject.search(
             text: searchText,
+            type: .typed,
             completion: { }
         )
 
@@ -107,6 +108,7 @@ struct SearchViewModelTests{
 
         subject.search(
             text: searchText,
+            type: .typed,
             completion: { }
         )
 
@@ -129,6 +131,7 @@ struct SearchViewModelTests{
 
         subject.search(
             text: searchText,
+            type: .autocomplete,
             completion: { }
         )
 


### PR DESCRIPTION
Renames searchButtonPressed to didInvokeSearch which is a bit more
reflective of its responsibilities (history + autocomplete).

Uses delegate method for handling the search return vs adding a target
which is cleaner as don't need to conform to `@objc` (e.g for the type
enum).