### PR TITLE
govukapp-1038 topics cant be displayed

### DIFF
--- a/Production/govuk_ios/Resources/Strings/Topics.xcstrings
+++ b/Production/govuk_ios/Resources/Strings/Topics.xcstrings
@@ -122,6 +122,17 @@
         }
       }
     },
+    "topicFetchErrorSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Topics are not working at the moment. Try again later, or go to the GOV.UK website to find the page you're looking for."
+          }
+        }
+      }
+    },
     "topicOnboardingCardSelected" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Production/govuk_ios/ViewModels/Topics/TopicsWidgetViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicsWidgetViewModel.swift
@@ -1,22 +1,26 @@
 import Foundation
+import UIKit
 import CoreData
+import GOVKit
 
 final class TopicsWidgetViewModel {
     private let topicsService: TopicsServiceInterface
+    let urlOpener: URLOpener
     let allTopicsAction: () -> Void
     let topicAction: (Topic) -> Void
     let editAction: () -> Void
-    private(set) var downloadError: TopicsServiceError?
+    var handleError: ((TopicsServiceError) -> Void)?
 
     init(topicsService: TopicsServiceInterface,
+         urlOpener: URLOpener = UIApplication.shared,
          topicAction: @escaping (Topic) -> Void,
          editAction: @escaping () -> Void,
          allTopicsAction: @escaping () -> Void) {
         self.topicsService = topicsService
+        self.urlOpener = urlOpener
         self.topicAction = topicAction
         self.editAction = editAction
         self.allTopicsAction = allTopicsAction
-        self.fetchTopics()
     }
 
     var allTopicsButtonHidden: Bool {
@@ -40,10 +44,25 @@ final class TopicsWidgetViewModel {
         topicsService.fetchAll().count
     }
 
-    private func fetchTopics() {
+    lazy var topicErrorViewModel: AppErrorViewModel = {
+        AppErrorViewModel(
+            title: String.common.localized("genericErrorTitle"),
+            body: String.topics.localized("topicFetchErrorSubtitle"),
+            buttonTitle: String.common.localized("genericErrorButtonTitle"),
+            buttonAccessibilityLabel: String.common.localized(
+                "genericErrorButtonTitleAccessibilityLabel"
+            ),
+            isWebLink: true,
+            action: {
+                self.urlOpener.openIfPossible(Constants.API.govukBaseUrl)
+            }
+        )
+    }()
+
+    func fetchTopics() {
         topicsService.fetchRemoteList { result in
             if case .failure(let error) = result {
-                self.downloadError = error
+                self.handleError?(error)
             }
         }
     }

--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -1,5 +1,6 @@
 import UIKit
 import UIComponents
+import GOVKit
 
 class TopicsWidgetView: UIView {
     let viewModel: TopicsWidgetViewModel
@@ -77,6 +78,20 @@ class TopicsWidgetView: UIView {
         return stackView
     }()
 
+    private lazy var appErrorViewController: HostingViewController = {
+        let localController = HostingViewController(
+            rootView: AppErrorView(
+                viewModel: self.viewModel.topicErrorViewModel
+            )
+        )
+        localController.view.backgroundColor = .clear
+        return localController
+    }()
+
+    private lazy var errorView: UIView = {
+        self.appErrorViewController.view
+    }()
+
     init(viewModel: TopicsWidgetViewModel) {
         self.viewModel = viewModel
         super.init(frame: .zero)
@@ -88,6 +103,7 @@ class TopicsWidgetView: UIView {
             name: .NSManagedObjectContextDidSave,
             object: nil
         )
+        fetchTopics()
         updateTopics(viewModel.displayedTopics)
         showAllTopicsButton()
     }
@@ -101,6 +117,16 @@ class TopicsWidgetView: UIView {
         }
     }
 
+    private func fetchTopics() {
+        viewModel.handleError = { _ in
+            self.cardStackView.isHidden = true
+            self.editButton.isHidden = true
+            self.allTopicsButton.isHidden = true
+            self.errorView.isHidden = false
+        }
+        viewModel.fetchTopics()
+    }
+
     private func configureUI() {
         headerStackView.addArrangedSubview(titleLabel)
         headerStackView.addArrangedSubview(UIView())
@@ -109,6 +135,8 @@ class TopicsWidgetView: UIView {
         stackView.addArrangedSubview(headerStackView)
         stackView.addArrangedSubview(cardStackView)
         stackView.addArrangedSubview(allTopicsButton)
+        stackView.addArrangedSubview(errorView)
+        errorView.isHidden = true
         addSubview(stackView)
     }
 
@@ -199,6 +227,7 @@ class TopicsWidgetView: UIView {
             rowCount = sizeClass == .regular ? 2 : 4
             updateTopics(viewModel.displayedTopics)
         }
+        errorView.invalidateIntrinsicContentSize()
     }
 
     private func showAllTopicsButton() {

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.HomeViewControllerSnapshotTests/test_loadInNavigationController_topicsError_darK_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.HomeViewControllerSnapshotTests/test_loadInNavigationController_topicsError_darK_rendersCorrectly@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2313f2ddd418e327352c2fd1c5e19f85aaa903f597dc94440a0f295ceaa72c7
+size 191205

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.HomeViewControllerSnapshotTests/test_loadInNavigationController_topicsError_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.HomeViewControllerSnapshotTests/test_loadInNavigationController_topicsError_rendersCorrectly@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0245c63e4cf62345147ed811ec80c8c3e48534e5f58dc6f2db180806a9f765a7
+size 191794

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/HomeViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/HomeViewControllerSnapshotTests.swift
@@ -62,6 +62,26 @@ class HomeViewControllerSnapshotTests: SnapshotTestCase {
         )
     }
 
+    func test_loadInNavigationController_topicsError_rendersCorrectly() {
+        mockTopicService._stubbedHasCustomisedTopics = false
+        mockTopicService._stubbedFetchRemoteListResult = .failure(.apiUnavailable)
+        VerifySnapshotInNavigationController(
+            viewController: viewController(),
+            mode: .light,
+            navBarHidden: true
+        )
+    }
+
+    func test_loadInNavigationController_topicsError_darK_rendersCorrectly() {
+        mockTopicService._stubbedHasCustomisedTopics = false
+        mockTopicService._stubbedFetchRemoteListResult = .failure(.apiUnavailable)
+        VerifySnapshotInNavigationController(
+            viewController: viewController(),
+            mode: .dark,
+            navBarHidden: true
+        )
+    }
+
     func viewController() -> HomeViewController {
         let topicsViewModel = TopicsWidgetViewModel(
             topicsService: mockTopicService,

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/Topics/TopicsWidgetViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/Topics/TopicsWidgetViewModelTests.swift
@@ -11,7 +11,7 @@ struct TopicsWidgetViewModelTests {
     let mockTopicService = MockTopicsService()
 
     @Test
-    func initializeModel_downloadSuccess_returnsExpectedData() async throws {
+    func fetchTopics_downloadSuccess_returnsExpectedData() async throws {
         mockTopicService._stubbedFetchRemoteListResult = .success(TopicResponseItem.arrangeMultiple)
 
         let sut = TopicsWidgetViewModel(
@@ -20,12 +20,17 @@ struct TopicsWidgetViewModelTests {
             editAction: { },
             allTopicsAction: { }
         )
+        var didHandleError = false
+        sut.handleError = { _ in
+            didHandleError = true
+        }
 
-        #expect(sut.downloadError == nil)
+        sut.fetchTopics()
+        #expect(didHandleError == false)
     }
 
     @Test
-    func initializeModel_downloadFailure_returnsExpectedResult() async throws {
+    func fetchTopics_downloadFailure_returnsExpectedResult() async throws {
         mockTopicService._stubbedFetchRemoteListResult = .failure(.decodingError)
 
         let sut = TopicsWidgetViewModel(
@@ -34,8 +39,16 @@ struct TopicsWidgetViewModelTests {
             editAction: { },
             allTopicsAction: { }
         )
+        var didHandleError = false
+        var topicsError: TopicsServiceError?
+        sut.handleError = { error in
+            didHandleError = true
+            topicsError = error
+        }
 
-        #expect(sut.downloadError == .decodingError)
+        sut.fetchTopics()
+        #expect(didHandleError == true)
+        #expect(topicsError == .decodingError)
     }
 
     @Test


### PR DESCRIPTION
Added AppErrorView to TopicsWidgetView
Updated error handling.  This required a refactor as we had been fetching the remote topics on view model instantiation, and saving the resulting error to the view model.  Just checking the error state could result in a race condition as the view may have finished loading before the result came back.   

Now the fetch is performed separately during view set up, and the view passes an error handler to the model when it is ready.