### PR TITLE
Add schedule steps

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -49,6 +49,7 @@ jobs:
           MATCH_CERTIFICATE_TOKEN: ${{ secrets.MATCH_CERTIFICATE_TOKEN }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          ONESIGNAL_APP_ID: ${{ env.ONESIGNAL_APP_ID }}
 
       - name: Save Artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # pin@v4.3.3

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -23,6 +23,7 @@ jobs:
     name: Deploy
     needs: sonar-scan
     runs-on: macos-15
+    environment: production
 
     steps:
       - name: Checkout
@@ -40,7 +41,6 @@ jobs:
         run: xcodes select
 
       - name: Deploy
-        environment: production
         run: bundle exec fastlane beta
         env:
           APP_STORE_KEY_CONTENT: ${{ secrets.APP_STORE_KEY_CONTENT }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -11,13 +11,14 @@ concurrency:
 
 jobs:
   validate:
+    runs-on: ubuntu-latest
     steps:
       - name: Confirm branch requirement
         run: |
-        if [[ "${{ github.ref }}" != "refs/heads/develop" ]]; then
-          echo "Branch is not develop, exiting."
-          exit 0
-        fi
+          if [[ "${{ github.ref }}" != "refs/heads/develop" ]]; then
+            echo "Branch is not develop, exiting."
+            exit 0
+          fi
   beta:
     uses: ./.github/workflows/beta.yml
     secrets:
@@ -28,5 +29,3 @@ jobs:
       APP_STORE_KEY_ISSUER_ID: ${{ secrets.APP_STORE_KEY_ISSUER_ID }}
       APP_STORE_USERNAME: ${{ secrets.APP_STORE_USERNAME }}
       MATCH_CERTIFICATE_TOKEN: ${{ secrets.MATCH_CERTIFICATE_TOKEN }}
-    env:
-      ONESIGNAL_APP_ID: ${{ env.ONESIGNAL_APP_ID }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -11,11 +11,13 @@ concurrency:
 
 jobs:
   validate:
-    run: |
-      if [[ "${{ github.ref }}" != "refs/heads/develop" ]]; then
-        echo "Branch is not develop, exiting."
-        exit 0
-      fi
+    steps:
+      - name: Confirm branch requirement
+        run: |
+        if [[ "${{ github.ref }}" != "refs/heads/develop" ]]; then
+          echo "Branch is not develop, exiting."
+          exit 0
+        fi
   beta:
     uses: ./.github/workflows/beta.yml
     secrets:

--- a/.github/workflows/sonar_scan_branch.yml
+++ b/.github/workflows/sonar_scan_branch.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run SonarCloud Scanning
         run: |
-          brew install sonar-scanner
+          brew install sonar-scanner@6.2.1
 
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \

--- a/.github/workflows/sonar_scan_branch.yml
+++ b/.github/workflows/sonar_scan_branch.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run SonarCloud Scanning
         run: |
-          brew install sonar-scanner@6.2.1
+          brew install sonar-scanner
 
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \

--- a/.github/workflows/sonar_scan_pr.yml
+++ b/.github/workflows/sonar_scan_pr.yml
@@ -39,6 +39,7 @@ jobs:
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 
           sonar-scanner \
+            -X \
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="test_output/sonarqube-generic-coverage.xml" \
             -Dsonar.pullrequest.key=$pull_number \

--- a/.github/workflows/sonar_scan_pr.yml
+++ b/.github/workflows/sonar_scan_pr.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run SonarCloud Scanning
         run: |
-          brew install sonar-scanner@6.2.1
+          brew install sonar-scanner
 
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 

--- a/.github/workflows/sonar_scan_pr.yml
+++ b/.github/workflows/sonar_scan_pr.yml
@@ -39,7 +39,6 @@ jobs:
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 
           sonar-scanner \
-            -X \
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="test_output/sonarqube-generic-coverage.xml" \
             -Dsonar.pullrequest.key=$pull_number \

--- a/.github/workflows/sonar_scan_pr.yml
+++ b/.github/workflows/sonar_scan_pr.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run SonarCloud Scanning
         run: |
-          brew install sonar-scanner
+          brew install sonar-scanner@6.2.1
 
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 

--- a/.github/workflows/sonar_scan_pr.yml
+++ b/.github/workflows/sonar_scan_pr.yml
@@ -26,6 +26,12 @@ jobs:
           lfs: 'true'
           fetch-depth: 0
 
+      - name: Setup JDK
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 #4.2.1
+        with:
+          java-version: 17
+          distribution: oracle
+
       - name: Download build output
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # pin@v4.1.7
         with:

--- a/GovUK.xcodeproj/xcshareddata/xcschemes/GovUK.xcscheme
+++ b/GovUK.xcodeproj/xcshareddata/xcschemes/GovUK.xcscheme
@@ -51,17 +51,6 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5DAD71932BD250DF0075F648"
-               BuildableName = "govuk_ios_ui_tests.xctest"
-               BlueprintName = "govuk_ios_ui_tests"
-               ReferencedContainer = "container:GovUK.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "5D4B9D332C074207005F126A"
                BuildableName = "govuk_ios_snapshot_tests.xctest"
                BlueprintName = "govuk_ios_snapshot_tests"

--- a/GovUK.xcodeproj/xcshareddata/xcschemes/GovUKAlpha.xcscheme
+++ b/GovUK.xcodeproj/xcshareddata/xcschemes/GovUKAlpha.xcscheme
@@ -51,17 +51,6 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5DAD71932BD250DF0075F648"
-               BuildableName = "govuk_ios_ui_tests.xctest"
-               BlueprintName = "govuk_ios_ui_tests"
-               ReferencedContainer = "container:GovUK.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "5D4B9D332C074207005F126A"
                BuildableName = "govuk_ios_snapshot_tests.xctest"
                BlueprintName = "govuk_ios_snapshot_tests"

--- a/GovUK.xcodeproj/xcshareddata/xcschemes/GovUKDev.xcscheme
+++ b/GovUK.xcodeproj/xcshareddata/xcschemes/GovUKDev.xcscheme
@@ -51,17 +51,6 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5DAD71932BD250DF0075F648"
-               BuildableName = "govuk_ios_ui_tests.xctest"
-               BlueprintName = "govuk_ios_ui_tests"
-               ReferencedContainer = "container:GovUK.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "5D4B9D332C074207005F126A"
                BuildableName = "govuk_ios_snapshot_tests.xctest"
                BlueprintName = "govuk_ios_snapshot_tests"


### PR DESCRIPTION
Temporarily setting java version, seems to allow us to brew install the older (unbroken) version of sonar-scanner.
Will revert when an updated sonar-scanner is released with the fix