### PR TITLE
[GOVUKAPP-1093] Remove extra padding for empty desc

### DIFF
--- a/Production/govuk_ios/Views/Search/SearchResultCell.swift
+++ b/Production/govuk_ios/Views/Search/SearchResultCell.swift
@@ -65,13 +65,19 @@ class SearchResultCell: UITableViewCell {
 
     func configure(item: SearchItem?) {
         titleLabel.text = item?.title
-        let trimmedDescription = item?.description?.trimmingCharacters(in: .whitespacesAndNewlines)
-        bodyLabel.text = trimmedDescription
+        card.accessibilityHint = String.common.localized("openWebLinkHint")
+
+        guard let description = item?.description else {
+            card.accessibilityLabel = titleLabel.text
+            bodyLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor).isActive = true
+            return
+        }
+
+        bodyLabel.text = description.trimmingCharacters(in: .whitespacesAndNewlines)
         card.accessibilityLabel = [
             titleLabel.text,
             bodyLabel.text
         ].compactMap { $0 }.joined(separator: ", ")
-        card.accessibilityHint = String.common.localized("openWebLinkHint")
     }
 
     private func setupUI() {

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.SearchViewControllerSnapshotTests/test_search_successResponse_withResults_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.SearchViewControllerSnapshotTests/test_search_successResponse_withResults_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c960ea58081c7e2ae7d2568bff6d16f983df7f3d2e35c2092722e3662c63d8f
-size 110567
+oid sha256:145f50eb5e049b8e11b38a18f149cbe8a3bcc970c45fe7c1736c6bff15394804
+size 118247

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SearchViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SearchViewControllerSnapshotTests.swift
@@ -24,10 +24,12 @@ class SearchViewControllerSnapshotTests: SnapshotTestCase {
     }
 
     func test_search_successResponse_withResults_rendersCorrectly() {
+        let url = URL(string: "https://www.gov.uk")!
         let result = SearchResult(
             results: [
-                .arrange(title: "Test 1", description: "Description 1"),
-                .arrange(title: "Test 2", description: "Description 2"),
+                SearchItem(title: "Test 1", description: "Description 1", link: url),
+                SearchItem(title: "Test 2", description: "Description 2", link: url),
+                SearchItem(title: "Test 3", description: nil, link: url)
             ]
         )
         let viewController = createViewController(result: .success(result))


### PR DESCRIPTION
When search results have a blank description there is extra padding applied even though the description label isn't visible. Attempted to mark the bodyLabel as hidden (`isHidden`) but the extra 8pts padding [1] still persists and thus I've just defined the constraint again, minus the constant. 

[1]: https://github.com/alphagov/govuk-mobile-ios-app/blob/be436a44072a249c7fbcdeb69364c3b822f1d51b/Production/govuk_ios/Views/Search/SearchResultCell.swift#L121-L123

