### PR TITLE
[GOVUKAPP-1130] Topics widget card breaking

### DIFF
--- a/Production/govuk_ios/Views/Home/Topics/TopicCard.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicCard.swift
@@ -29,6 +29,7 @@ class TopicCard: UIView {
         imageView.preferredSymbolConfiguration = config
         imageView.tintColor = UIColor.govUK.strokes.listDivider
         imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        imageView.widthAnchor.constraint(greaterThanOrEqualToConstant: 9).isActive = true
         return imageView
     }()
 

--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -2,10 +2,11 @@ import UIKit
 import UIComponents
 import GOVKit
 
+// swiftlint:disable:next type_body_length
 class TopicsWidgetView: UIView {
     let viewModel: TopicsWidgetViewModel
 
-    private var rowCount = 2
+    private var columnCount = 2
     private lazy var allTopicsButton: GOVUKButton = {
         var buttonViewModel: GOVUKButton.ButtonViewModel {
             .init(
@@ -180,7 +181,8 @@ class TopicsWidgetView: UIView {
     private func updateTopics(_ topics: [Topic]) {
         noTopicsLabel.isHidden = viewModel.fetchTopicsError || topics.count > 0
         cardStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        for index in 0..<topics.count where index % rowCount == 0 {
+        setColumnCount(topics)
+        for index in 0..<topics.count where index % columnCount == 0 {
             let rowStack = createNewRow(startingAt: index, of: topics)
             rowStack.translatesAutoresizingMaskIntoConstraints = false
             cardStackView.addArrangedSubview(rowStack)
@@ -198,7 +200,7 @@ class TopicsWidgetView: UIView {
         let firstCard = createTopicCard(for: topics[startIndex])
         rowStack.addArrangedSubview(firstCard)
 
-        for index in (startIndex + 1)..<(startIndex + rowCount) {
+        for index in (startIndex + 1)..<(startIndex + columnCount) {
             if index <= topics.count - 1 {
                 let card = createTopicCard(for: topics[index])
                 rowStack.addArrangedSubview(card)
@@ -237,12 +239,50 @@ class TopicsWidgetView: UIView {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        let sizeClass = UITraitCollection.current.verticalSizeClass
-        if sizeClass != previousTraitCollection?.verticalSizeClass {
-            rowCount = sizeClass == .regular ? 2 : 4
+
+        let contentSizeChanged = traitCollection.preferredContentSizeCategory !=
+        previousTraitCollection?.preferredContentSizeCategory
+        let sizeClassChanged = traitCollection.verticalSizeClass !=
+        previousTraitCollection?.verticalSizeClass
+
+        if sizeClassChanged || contentSizeChanged {
             updateTopics(viewModel.displayedTopics)
         }
+
         errorView.invalidateIntrinsicContentSize()
+    }
+
+    private func setColumnCount(_ topics: [Topic]) {
+        layoutIfNeeded()
+        let sizeClass = UITraitCollection.current.verticalSizeClass
+        let defaultColumnCount = sizeClass == .regular ? 2 : 4
+        // Horizontal card space not available to title + spacing between cards
+        let unavailableTitleCardWidth = (50 * defaultColumnCount) + (16 * (defaultColumnCount - 1))
+        let availableTitleCardWidth = (bounds.width - CGFloat(unavailableTitleCardWidth)) /
+        CGFloat(defaultColumnCount)
+        let reduceColumnCount = shouldReduceColumnCount(
+            for: availableTitleCardWidth, topics: topics
+        )
+
+        if sizeClass == .regular {
+            columnCount = reduceColumnCount ? 1 : 2
+        } else {
+            columnCount = reduceColumnCount ? 2 : 4
+        }
+    }
+
+    private func shouldReduceColumnCount(for availableTitleCardWidth: CGFloat,
+                                         topics: [Topic]) -> Bool {
+        let longestWord = topics.flatMap {
+            $0.title.components(separatedBy: .whitespacesAndNewlines)
+        }.max { $0.count < $1.count } ?? ""
+        let wordSize = (longestWord as NSString).size(
+            withAttributes: [.font: UIFont.govUK.body]
+        )
+        if wordSize.width > availableTitleCardWidth {
+            return true
+        }
+        return false
     }
 
     private func showAllTopicsButton() {

--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -181,7 +181,6 @@ class TopicsWidgetView: UIView {
     private func updateTopics(_ topics: [Topic]) {
         noTopicsLabel.isHidden = viewModel.fetchTopicsError || topics.count > 0
         cardStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        setColumnCount(topics)
         for index in 0..<topics.count where index % columnCount == 0 {
             let rowStack = createNewRow(startingAt: index, of: topics)
             rowStack.translatesAutoresizingMaskIntoConstraints = false
@@ -244,7 +243,7 @@ class TopicsWidgetView: UIView {
         previousTraitCollection?.preferredContentSizeCategory
         let sizeClassChanged = traitCollection.verticalSizeClass !=
         previousTraitCollection?.verticalSizeClass
-
+        setColumnCount(viewModel.displayedTopics)
         if sizeClassChanged || contentSizeChanged {
             updateTopics(viewModel.displayedTopics)
         }


### PR DESCRIPTION
Make topic cards larger depending on the dynamic type set. The main
driver of this is to prevent multiple line hyphenation of words
in the topic titles. Topic cards will now break if a word is larger than
the available card width space.

More info in the commits ->

## Screenshots

![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 00 48 04](https://github.com/user-attachments/assets/9a98f6f9-6eb4-4aa4-9f74-746ded36758c)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-06 at 00 48 18](https://github.com/user-attachments/assets/2ab210c0-aa8c-4bd9-b31f-1a0f2150ee10)
