### PR TITLE
Adds fix for Java runtime error for branch worflow

### DIFF
--- a/.github/workflows/sonar_scan_branch.yml
+++ b/.github/workflows/sonar_scan_branch.yml
@@ -44,6 +44,8 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_SCANNER_OPTS: -Dorg.bouncycastle.pkcs12.ignore_useless_passwd=true
+          SONAR_SCANNER_JAVA_OPTS: -Dorg.bouncycastle.pkcs12.ignore_useless_passwd=true
 
       - name: Check SonarCloud Results
         uses: sonarsource/sonarqube-quality-gate-action@d304d050d930b02a896b0f85935344f023928496 # pin@v1.1.0

--- a/.github/workflows/sonar_scan_pr.yml
+++ b/.github/workflows/sonar_scan_pr.yml
@@ -13,9 +13,6 @@ concurrency:
 
 jobs:
   build:
-    env:
-      SONAR_SCANNER_OPTS: -Dorg.bouncycastle.pkcs12.ignore_useless_passwd=true
-      SONAR_SCANNER_JAVA_OPTS: -Dorg.bouncycastle.pkcs12.ignore_useless_passwd=true
     name: Sonar scan
     runs-on: macos-15
 
@@ -51,6 +48,8 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_SCANNER_OPTS: -Dorg.bouncycastle.pkcs12.ignore_useless_passwd=true
+          SONAR_SCANNER_JAVA_OPTS: -Dorg.bouncycastle.pkcs12.ignore_useless_passwd=true
 
       - name: Check SonarCloud Results
         uses: sonarsource/sonarqube-quality-gate-action@d304d050d930b02a896b0f85935344f023928496 # pin@v1.1.0


### PR DESCRIPTION
For sonar-scanner versions 7.xx we're getting a Java runtime error. Brew
seems to either install either 6.2 or 7.0 everytime we run `brew install
sonar-scanner`. 

6.2 builds pass fine. There doesn't seem to be an easy
way to install specific versions of packages through brew.

The below error is returned for version 7.0 and is a known bug. There is
a workaround [1] implemented in this PR. Tested on versions 6.2 and 7.0
and run successfully.

An alternative workaround is to ensure we're using Java 17 which doesn't
have the issue (implemented [2] and then revoked).

The problem should be fixed in future versions of sonar-scanner and thus
we can then remove the env vars.

```
...
Caused by: java.io.IOException: password supplied for keystore that does not require one
```

Also moves setting env vars to relevant job in sonar_scan_pr.

[1]: https://community.sonarsource.com/t/unable-to-read-truststore-error-since-macos-sonar-scanner-cli-since-7-0-0-4796/133776/13
[2]: https://github.com/alphagov/govuk-mobile-ios-app/commit/d9ec212ab702de55c756a9ab5844b12d5a127afe