### PR TITLE
govukapp-1148 home ecommerce tracking

### DIFF
--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -191,6 +191,9 @@
 		D04191862CA6A59D0034722A /* TopicsServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04191852CA6A5910034722A /* TopicsServiceClient.swift */; };
 		D046511D2C933FE600F47C66 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D046511C2C933FE600F47C66 /* String+Extensions.swift */; };
 		D04A8F4B2CD3949800685FD3 /* URLResponse+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04A8F4A2CD3948B00685FD3 /* URLResponse+Extensions.swift */; };
+		D04C542C2D7081CC0070EE79 /* TopicCommerceItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04C542B2D7081CC0070EE79 /* TopicCommerceItem.swift */; };
+		D04C542E2D7082000070EE79 /* ECommerceItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04C542D2D7082000070EE79 /* ECommerceItem.swift */; };
+		D04C54302D70821D0070EE79 /* HomeCommerceItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04C542F2D70821D0070EE79 /* HomeCommerceItem.swift */; };
 		D056CE742D3A83F2005845E0 /* UserFeedbackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D056CE732D3A83F2005845E0 /* UserFeedbackViewModel.swift */; };
 		D056CE762D3A848A005845E0 /* UserFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D056CE752D3A847F005845E0 /* UserFeedbackView.swift */; };
 		D05AF4DA2CAD3C2900F86DD0 /* TopicDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05AF4D92CAD3C2900F86DD0 /* TopicDetailView.swift */; };
@@ -458,6 +461,9 @@
 		D04191852CA6A5910034722A /* TopicsServiceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsServiceClient.swift; sourceTree = "<group>"; };
 		D046511C2C933FE600F47C66 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		D04A8F4A2CD3948B00685FD3 /* URLResponse+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLResponse+Extensions.swift"; sourceTree = "<group>"; };
+		D04C542B2D7081CC0070EE79 /* TopicCommerceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicCommerceItem.swift; sourceTree = "<group>"; };
+		D04C542D2D7082000070EE79 /* ECommerceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ECommerceItem.swift; sourceTree = "<group>"; };
+		D04C542F2D70821D0070EE79 /* HomeCommerceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCommerceItem.swift; sourceTree = "<group>"; };
 		D056CE732D3A83F2005845E0 /* UserFeedbackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedbackViewModel.swift; sourceTree = "<group>"; };
 		D056CE752D3A847F005845E0 /* UserFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedbackView.swift; sourceTree = "<group>"; };
 		D05AF4D92CAD3C2900F86DD0 /* TopicDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicDetailView.swift; sourceTree = "<group>"; };
@@ -1148,6 +1154,7 @@
 		5DE970512C297637009D66C4 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				D04C542A2D7081C00070EE79 /* Analytics */,
 				D0D9CB922D3024C00051EDDD /* Search */,
 				4E003E7D2C75F497008FCBF2 /* AppConfig */,
 				5D8100882CEB3FE600EE7D15 /* AppLaunchResponse.swift */,
@@ -1210,6 +1217,16 @@
 				4E00EEF62CCB0788007B61E8 /* TopicOnboardingCardModel.swift */,
 			);
 			path = Topics;
+			sourceTree = "<group>";
+		};
+		D04C542A2D7081C00070EE79 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				D04C542D2D7082000070EE79 /* ECommerceItem.swift */,
+				D04C542F2D70821D0070EE79 /* HomeCommerceItem.swift */,
+				D04C542B2D7081CC0070EE79 /* TopicCommerceItem.swift */,
+			);
+			path = Analytics;
 			sourceTree = "<group>";
 		};
 		D05AF4DD2CAD3C5500F86DD0 /* Topics */ = {
@@ -1617,6 +1634,7 @@
 				168F6FA82C4FC1D200A0D7F7 /* HomeViewModel.swift in Sources */,
 				5D54A82E2BFCAA4E003D0C21 /* LaunchViewController.swift in Sources */,
 				5D8100892CEB3FE600EE7D15 /* AppLaunchResponse.swift in Sources */,
+				D04C54302D70821D0070EE79 /* HomeCommerceItem.swift in Sources */,
 				3D7E2D182C81FB1B0016BEEC /* AnalyticsConsentCoordinator.swift in Sources */,
 				3D9C933E2CB0172400EFA337 /* AppForcedUpdateContainerView.swift in Sources */,
 				1687F3172CB4110D005E1473 /* AllTopicsViewModel.swift in Sources */,
@@ -1664,6 +1682,7 @@
 				16D17D422CC01C7600E99794 /* TopicRowView.swift in Sources */,
 				D0C1F1E62CA4434100DD3D61 /* TopicsWidgetView.swift in Sources */,
 				D0F5FF7E2D64D22400C3BF51 /* AppEvent+ECommerce.swift in Sources */,
+				D04C542C2D7081CC0070EE79 /* TopicCommerceItem.swift in Sources */,
 				5D0BD45B2C9B206F00220625 /* JSONDecoder+Extensions.swift in Sources */,
 				4EFE22A52D0CD0D500136D56 /* RegexRedactor.swift in Sources */,
 				D028CCF62CB9619B00742620 /* Topic.swift in Sources */,
@@ -1684,6 +1703,7 @@
 				4E5ED2012C6E06FB00750BDA /* AppConfigService.swift in Sources */,
 				16E5AD432C6D5719000B8B3A /* SearchWidgetStackView.swift in Sources */,
 				4E9AFCE32C99D43B00DBF66F /* AnalyticsConsentContainerView.swift in Sources */,
+				D04C542E2D7082000070EE79 /* ECommerceItem.swift in Sources */,
 				4E00EEF72CCB0788007B61E8 /* TopicOnboardingCardModel.swift in Sources */,
 				5D899A222C946F8A0074C0AD /* UIBarButtonItem+Convenience.swift in Sources */,
 				5DBE08082C480CA700B58DBE /* UITabBarItem+Convenience.swift in Sources */,

--- a/Production/govuk_ios/Coordinators/HomeCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/HomeCoordinator.swift
@@ -137,6 +137,7 @@ class HomeCoordinator: TabItemCoordinator {
     private var topicWidgetViewModel: TopicsWidgetViewModel {
         TopicsWidgetViewModel(
             topicsService: topicsService,
+            analyticsService: analyticsService,
             topicAction: startTopicDetailCoordinator,
             editAction: presentEditTopicsCoordinator,
             allTopicsAction: startAllTopicsCoordinator

--- a/Production/govuk_ios/Extensions/Analytics/AppEvent+ECommerce.swift
+++ b/Production/govuk_ios/Extensions/Analytics/AppEvent+ECommerce.swift
@@ -3,23 +3,42 @@ import GOVKit
 
 extension AppEvent {
     static func viewItemList(name: String,
+                             id: String,
                              items: [ECommerceItem]) -> AppEvent {
         return .init(
             name: "view_item_list",
-            params: ["item_list_name": "Topics",
-                     "item_list_id": name,
+            params: ["item_list_name": name,
+                     "item_list_id": id,
                      "results": items.count,
                      "items": items.map { $0.eventParameters() }]
         )
     }
 
-    static func selectItem(name: String,
+    static func selectTopicItem(name: String,
+                                results: Int,
+                                items: [ECommerceItem]) -> AppEvent {
+        selectItem(listName: "Topics / " + name,
+                   listId: name,
+                   results: results,
+                   items: items)
+    }
+
+    static func selectHomePageItem(results: Int,
+                                   items: [ECommerceItem]) -> AppEvent {
+        selectItem(listName: "Homepage",
+                   listId: "Homepage",
+                   results: results,
+                   items: items)
+    }
+
+    static func selectItem(listName: String,
+                           listId: String,
                            results: Int,
                            items: [ECommerceItem]) -> AppEvent {
         return .init(
             name: "select_item",
-            params: ["item_list_name": "Topics / " + name,
-                     "item_list_id": name,
+            params: ["item_list_name": listName,
+                     "item_list_id": listId,
                      "results": results,
                      "items": items.map { $0.eventParameters() }]
         )

--- a/Production/govuk_ios/Model/Analytics/ECommerceItem.swift
+++ b/Production/govuk_ios/Model/Analytics/ECommerceItem.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol ECommerceItem {
+    func eventParameters() -> [String: String]
+}

--- a/Production/govuk_ios/Model/Analytics/HomeCommerceItem.swift
+++ b/Production/govuk_ios/Model/Analytics/HomeCommerceItem.swift
@@ -1,18 +1,16 @@
 import Foundation
-public struct ECommerceItem {
+
+public struct HomeCommerceItem: ECommerceItem {
     public let name: String
-    public let category: String
     public let index: Int
     public let itemId: String?
     public let locationId: String?
 
     public init(name: String,
-                category: String,
                 index: Int,
                 itemId: String?,
                 locationId: String?) {
         self.name = name
-        self.category = category
         self.index = index
         self.itemId = itemId
         self.locationId = locationId
@@ -20,8 +18,8 @@ public struct ECommerceItem {
 
     public func eventParameters() -> [String: String] {
         ["item_name": name,
-         "item_category": category,
          "index": "\(index)",
+         "item_list_id": "Homepage",
          "item_id": itemId ?? "",
          "location_id": locationId ?? ""]
     }

--- a/Production/govuk_ios/Model/Analytics/TopicCommerceItem.swift
+++ b/Production/govuk_ios/Model/Analytics/TopicCommerceItem.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct TopicCommerceItem: ECommerceItem {
+    public let name: String
+    public let category: String
+    public let index: Int
+    public let itemId: String?
+    public let locationId: String?
+
+    public init(name: String,
+                category: String,
+                index: Int,
+                itemId: String?,
+                locationId: String?) {
+        self.name = name
+        self.category = category
+        self.index = index
+        self.itemId = itemId
+        self.locationId = locationId
+    }
+
+    public func eventParameters() -> [String: String] {
+        ["item_name": name,
+         "item_category": category,
+         "index": "\(index)",
+         "item_id": itemId ?? "",
+         "location_id": locationId ?? ""]
+    }
+}

--- a/Production/govuk_ios/ViewModels/Topics/StepByStepsViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/StepByStepsViewModel.swift
@@ -4,7 +4,7 @@ import RecentActivity
 
 class StepByStepsViewModel: TopicDetailViewModelInterface {
     var errorViewModel: AppErrorViewModel?
-    var commerceItems = [ECommerceItem]()
+    var commerceItems = [TopicCommerceItem]()
     private let content: [TopicDetailResponse.Content]
     private let analyticsService: AnalyticsServiceInterface
     private let activityService: ActivityServiceInterface
@@ -45,7 +45,8 @@ class StepByStepsViewModel: TopicDetailViewModelInterface {
 
     func trackEcommerce() {
         let eCommerceEvent = AppEvent.viewItemList(
-            name: String.topics.localized("topicDetailStepByStepHeader"),
+            name: "Topics",
+            id: String.topics.localized("topicDetailStepByStepHeader"),
             items: commerceItems
         )
         analyticsService.track(event: eCommerceEvent)

--- a/Production/govuk_ios/ViewModels/Topics/TopicDetailViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicDetailViewModel.swift
@@ -5,7 +5,7 @@ import RecentActivity
 class TopicDetailViewModel: TopicDetailViewModelInterface {
     @Published private(set) var sections = [GroupedListSection]()
     @Published private(set) var errorViewModel: AppErrorViewModel?
-    var commerceItems = [ECommerceItem]()
+    var commerceItems = [TopicCommerceItem]()
 
     private var topicDetail: TopicDetailResponse?
     private var topic: DisplayableTopic
@@ -215,7 +215,8 @@ class TopicDetailViewModel: TopicDetailViewModelInterface {
 
     func trackEcommerce() {
         let eCommerceEvent = AppEvent.viewItemList(
-            name: topic.title,
+            name: "Topics",
+            id: topic.title,
             items: commerceItems
         )
         analyticsService.track(event: eCommerceEvent)
@@ -255,7 +256,7 @@ class TopicDetailViewModel: TopicDetailViewModelInterface {
 
     private func createSubtopicCommerceItem(_ subtopic: TopicDetailResponse.Subtopic,
                                             category: String) {
-        let appEventItem = ECommerceItem(
+        let appEventItem = TopicCommerceItem(
             name: subtopic.title,
             category: category,
             index: commerceItems.count + 1,
@@ -267,7 +268,7 @@ class TopicDetailViewModel: TopicDetailViewModelInterface {
 
     private func createSeeAllCommerceItem(_ rowTitle: String,
                                           category: String) {
-        let appEventItem = ECommerceItem(
+        let appEventItem = TopicCommerceItem(
             name: rowTitle,
             category: category,
             index: commerceItems.count + 1,

--- a/Production/govuk_ios/ViewModels/Topics/TopicDetailViewModelInterface.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicDetailViewModelInterface.swift
@@ -8,7 +8,7 @@ protocol TopicDetailViewModelInterface: ObservableObject {
     var sections: [GroupedListSection] { get }
     var errorViewModel: AppErrorViewModel? { get }
     func trackScreen(screen: TrackableScreen)
-    var commerceItems: [ECommerceItem] { get set }
+    var commerceItems: [TopicCommerceItem] { get set }
     func trackEcommerce()
 }
 
@@ -17,7 +17,7 @@ extension TopicDetailViewModelInterface {
         guard let commerceItem = commerceItems.first(where: { $0.name == name}) else {
             return nil
         }
-        let event = AppEvent.selectItem(
+        let event = AppEvent.selectTopicItem(
             name: name,
             results: commerceItems.count,
             items: [commerceItem]
@@ -27,7 +27,7 @@ extension TopicDetailViewModelInterface {
 
     func createCommerceItem(_ content: TopicDetailResponse.Content,
                             category: String) {
-        let appEventItem = ECommerceItem(
+        let appEventItem = TopicCommerceItem(
             name: content.title,
             category: category,
             index: commerceItems.count + 1,

--- a/Production/govuk_ios/ViewModels/Topics/TopicsWidgetViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicsWidgetViewModel.swift
@@ -5,6 +5,7 @@ import GOVKit
 
 final class TopicsWidgetViewModel {
     private let topicsService: TopicsServiceInterface
+    private let analyticsService: AnalyticsServiceInterface
     let urlOpener: URLOpener
     let allTopicsAction: () -> Void
     let topicAction: (Topic) -> Void
@@ -13,11 +14,13 @@ final class TopicsWidgetViewModel {
     var fetchTopicsError: Bool = false
 
     init(topicsService: TopicsServiceInterface,
+         analyticsService: AnalyticsServiceInterface,
          urlOpener: URLOpener = UIApplication.shared,
          topicAction: @escaping (Topic) -> Void,
          editAction: @escaping () -> Void,
          allTopicsAction: @escaping () -> Void) {
         self.topicsService = topicsService
+        self.analyticsService = analyticsService
         self.urlOpener = urlOpener
         self.topicAction = topicAction
         self.editAction = editAction
@@ -70,5 +73,39 @@ final class TopicsWidgetViewModel {
                 self?.fetchTopicsError = false
             }
         }
+    }
+
+    func trackECommerce() {
+        let trackedTopics = displayedTopics
+        let count = trackedTopics.count
+        var items = [HomeCommerceItem]()
+        trackedTopics.enumerated().forEach { index, topic in
+            let item = HomeCommerceItem(name: topic.title,
+                                        index: index + 1,
+                                        itemId: nil,
+                                        locationId: nil)
+            items.append(item)
+        }
+        let event = AppEvent.viewItemList(name: "Homepage",
+                                          id: "Homepage",
+                                          items: items)
+        analyticsService.track(event: event)
+    }
+
+    func trackECommerceSelection(_ name: String) {
+        let trackedTopics = displayedTopics
+        guard let topic = trackedTopics.first(where: {$0.title == name}),
+              let index = trackedTopics.firstIndex(of: topic) else {
+            return
+        }
+        let items = [HomeCommerceItem(name: topic.title,
+                                      index: index + 1,
+                                      itemId: nil,
+                                      locationId: nil)]
+
+        let event = AppEvent.selectHomePageItem(
+            results: trackedTopics.count,
+            items: items)
+        analyticsService.track(event: event)
     }
 }

--- a/Production/govuk_ios/ViewModels/Topics/TopicsWidgetViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicsWidgetViewModel.swift
@@ -45,10 +45,6 @@ final class TopicsWidgetViewModel {
         topicsService.fetchAll()
     }
 
-    var topicCount: Int {
-        topicsService.fetchAll().count
-    }
-
     lazy var topicErrorViewModel: AppErrorViewModel = {
         AppErrorViewModel(
             title: String.common.localized("genericErrorTitle"),
@@ -77,7 +73,6 @@ final class TopicsWidgetViewModel {
 
     func trackECommerce() {
         let trackedTopics = displayedTopics
-        let count = trackedTopics.count
         var items = [HomeCommerceItem]()
         trackedTopics.enumerated().forEach { index, topic in
             let item = HomeCommerceItem(name: topic.title,

--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -125,6 +125,7 @@ class TopicsWidgetView: UIView {
     private func topicsDidUpdate(notification: Notification) {
         DispatchQueue.main.async {
             self.updateTopics(self.viewModel.displayedTopics)
+            self.viewModel.trackECommerce()
             self.showAllTopicsButton()
             self.titleLabel.text = self.viewModel.widgetTitle
         }
@@ -225,6 +226,7 @@ class TopicsWidgetView: UIView {
             topic: topic,
             tapAction: { [weak self] in
                 self?.viewModel.topicAction(topic)
+                self?.viewModel.trackECommerceSelection(topic.title)
             }
         )
         let topicCard = TopicCard(viewModel: topicCardModel)

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/HomeViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/HomeViewControllerSnapshotTests.swift
@@ -8,6 +8,7 @@ import UIKit
 class HomeViewControllerSnapshotTests: SnapshotTestCase {
     let coreData = CoreDataRepository.arrangeAndLoad
     let mockTopicService = MockTopicsService()
+    let mockAnalyticsService = MockAnalyticsService()
 
     func test_loadInNavigationController_light_rendersCorrectly() {
         mockTopicService._stubbedHasCustomisedTopics = true
@@ -117,6 +118,7 @@ class HomeViewControllerSnapshotTests: SnapshotTestCase {
     func viewController() -> HomeViewController {
         let topicsViewModel = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: mockAnalyticsService,
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Extensions/Analytics/AppEvent+EcommerceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Extensions/Analytics/AppEvent+EcommerceTests.swift
@@ -7,18 +7,20 @@ import GOVKit
 @Suite
 struct AppEvent_EcommerceTests {
     @Test
-    func viewItemList_returnsExpectedResult() throws {
+    func viewItemList_topics_returnsExpectedResult() throws {
         let expectedName = UUID().uuidString
-        let expectedItems = ECommerceItem.arrangeItems(count: 3)
+        let expectedId = UUID().uuidString
+        let expectedItems = TopicCommerceItem.arrangeItems(count: 3)
         let result = AppEvent.viewItemList(
             name: expectedName,
+            id: expectedId,
             items: expectedItems
         )
 
         #expect(result.name == "view_item_list")
         #expect(result.params?.count == 4)
-        #expect(result.params?["item_list_id"] as? String == expectedName)
-        #expect(result.params?["item_list_name"] as? String == "Topics")
+        #expect(result.params?["item_list_id"] as? String == expectedId)
+        #expect(result.params?["item_list_name"] as? String == expectedName)
         #expect(result.params?["results"] as? Int == 3)
         #expect((result.params?["items"] as? [[String: String]])?.count == 3)
         let firstItem = try #require((result.params?["items"] as? [[String: String]])?.first)
@@ -30,11 +32,36 @@ struct AppEvent_EcommerceTests {
     }
 
     @Test
-    func selectItem_returnsExpectedResult() throws {
+    func viewItemList_homepage_returnsExpectedResult() throws {
         let expectedName = UUID().uuidString
-        let expectedItems = ECommerceItem.arrangeItems(count: 1)
+        let expectedId = UUID().uuidString
+        let expectedItems = HomeCommerceItem.arrangeItems(count: 3)
+        let result = AppEvent.viewItemList(
+            name: expectedName,
+            id: expectedId,
+            items: expectedItems
+        )
+
+        #expect(result.name == "view_item_list")
+        #expect(result.params?.count == 4)
+        #expect(result.params?["item_list_id"] as? String == expectedId)
+        #expect(result.params?["item_list_name"] as? String == expectedName)
+        #expect(result.params?["results"] as? Int == 3)
+        #expect((result.params?["items"] as? [[String: String]])?.count == 3)
+        let firstItem = try #require((result.params?["items"] as? [[String: String]])?.first)
+        #expect(firstItem["item_name"] == "name 1")
+        #expect(firstItem["item_id"] == "item_id 1")
+        #expect(firstItem["location_id"] == "location_id 1")
+        #expect(firstItem["index"] == "1")
+    }
+
+    @Test
+    func selectTopicItem_returnsExpectedResult() throws {
+        let expectedName = UUID().uuidString
+        let expectedId = UUID().uuidString
+        let expectedItems = TopicCommerceItem.arrangeItems(count: 1)
         let expectedResultCount = 3
-        let result = AppEvent.selectItem(
+        let result = AppEvent.selectTopicItem(
             name: expectedName,
             results: expectedResultCount,
             items: expectedItems
@@ -54,23 +81,64 @@ struct AppEvent_EcommerceTests {
         #expect(firstItem["index"] == "1")
     }
 
+    @Test
+    func selectHomePageItem_returnsExpectedResult() throws {
+        let expectedItems = HomeCommerceItem.arrangeItems(count: 1)
+        let expectedResultCount = 3
+        let result = AppEvent.selectHomePageItem(
+            results: expectedResultCount,
+            items: expectedItems
+        )
+
+        #expect(result.name == "select_item")
+        #expect(result.params?.count == 4)
+        #expect(result.params?["item_list_id"] as? String == "Homepage")
+        #expect(result.params?["item_list_name"] as? String == "Homepage")
+        #expect(result.params?["results"] as? Int == expectedResultCount)
+        #expect((result.params?["items"] as? [[String: String]])?.count == 1)
+        let firstItem = try #require((result.params?["items"] as? [[String: String]])?.first)
+        #expect(firstItem["item_name"] == "name 1")
+        #expect(firstItem["item_id"] == "item_id 1")
+        #expect(firstItem["location_id"] == "location_id 1")
+        #expect(firstItem["index"] == "1")
+    }
+
 }
 
-extension ECommerceItem {
-    static func arrange(index: Int) -> ECommerceItem {
-        ECommerceItem(name: "name \(index)",
+extension TopicCommerceItem {
+    static func arrange(index: Int) -> TopicCommerceItem {
+        TopicCommerceItem(name: "name \(index)",
                       category: "category",
                       index: index,
                       itemId: "item_id \(index)",
                       locationId: "location_id \(index)")
     }
 
-    static func arrangeItems(count: Int) -> [ECommerceItem] {
-        var items = [ECommerceItem]()
+    static func arrangeItems(count: Int) -> [TopicCommerceItem] {
+        var items = [TopicCommerceItem]()
         for index in 1...count {
-            let item = ECommerceItem.arrange(index: index)
+            let item = TopicCommerceItem.arrange(index: index)
             items.append(item)
         }
         return items
+    }
+}
+
+extension HomeCommerceItem {
+    static func arrange(index: Int) -> HomeCommerceItem {
+        HomeCommerceItem(name: "name \(index)",
+                         index: index,
+                         itemId: "item_id \(index)",
+                         locationId: "location_id \(index)")
+    }
+    
+    static func arrangeItems(count: Int) -> [HomeCommerceItem] {
+        var items = [HomeCommerceItem]()
+        for index in 1...count {
+            let item = HomeCommerceItem.arrange(index: index)
+            items.append(item)
+        }
+        return items
+
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
@@ -18,6 +18,7 @@ struct ViewControllerBuilderTests {
         let subject = ViewControllerBuilder()
         let viewModel = TopicsWidgetViewModel(
             topicsService: MockTopicsService(),
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/HomeViewControllerTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/HomeViewControllerTests.swift
@@ -12,6 +12,7 @@ struct HomeViewControllerTests {
     func init_hasExpectedValues() {
         let topicsViewModel = TopicsWidgetViewModel(
             topicsService: MockTopicsService(),
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }
@@ -34,6 +35,7 @@ struct HomeViewControllerTests {
         let mockAnalyticsService = MockAnalyticsService()
         let topicsViewModel = TopicsWidgetViewModel(
             topicsService: MockTopicsService(),
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }
@@ -60,6 +62,7 @@ struct HomeViewControllerTests {
     func scrollToTop_scrollsContentToTop() {
         let topicsViewModel = TopicsWidgetViewModel(
             topicsService: MockTopicsService(),
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/HomeViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/HomeViewModelTests.swift
@@ -11,6 +11,7 @@ struct HomeViewModelTests {
     func widgets_returnsArrayOfWidgets() {
         let topicsViewModel = TopicsWidgetViewModel(
             topicsService: MockTopicsService(),
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }
@@ -36,6 +37,7 @@ struct HomeViewModelTests {
 
         let topicsViewModel = TopicsWidgetViewModel(
             topicsService: MockTopicsService(),
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/Topics/TopicsWidgetViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/Topics/TopicsWidgetViewModelTests.swift
@@ -16,6 +16,7 @@ struct TopicsWidgetViewModelTests {
 
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }
@@ -35,6 +36,7 @@ struct TopicsWidgetViewModelTests {
 
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }
@@ -57,6 +59,7 @@ struct TopicsWidgetViewModelTests {
         var expectedValue = false
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in
                 expectedValue = true
             },
@@ -73,6 +76,7 @@ struct TopicsWidgetViewModelTests {
         var expectedValue = false
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: {
                 expectedValue = true
@@ -89,6 +93,7 @@ struct TopicsWidgetViewModelTests {
         var expectedValue = false
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: {
@@ -115,6 +120,7 @@ struct TopicsWidgetViewModelTests {
 
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }
@@ -141,6 +147,7 @@ struct TopicsWidgetViewModelTests {
 
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }
@@ -165,6 +172,7 @@ struct TopicsWidgetViewModelTests {
 
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }
@@ -186,6 +194,7 @@ struct TopicsWidgetViewModelTests {
 
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }
@@ -209,6 +218,7 @@ struct TopicsWidgetViewModelTests {
 
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }
@@ -222,6 +232,7 @@ struct TopicsWidgetViewModelTests {
         mockTopicService._stubbedHasCustomisedTopics = true
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }
@@ -235,6 +246,7 @@ struct TopicsWidgetViewModelTests {
         mockTopicService._stubbedHasCustomisedTopics = false
         let sut = TopicsWidgetViewModel(
             topicsService: mockTopicService,
+            analyticsService: MockAnalyticsService(),
             topicAction: { _ in },
             editAction: { },
             allTopicsAction: { }


### PR DESCRIPTION
Add ecommerce tracking to the home page, as per [spec](https://docs.google.com/spreadsheets/d/1GJzMF7F3Xgujv2sowfNu3HyYGxmQ3rF3xqHye24rb-o/edit?pli=1&gid=1502926465#gid=1502926465)
Refactored EcommerceItem to be a protocol, with implementations of TopicsCommerceItem and HomeCommerceItem.  Moved all of this to govuk_ios, as did not seem general enough for GOVKit.
Added convenience methods for select_item events for home and topics.
At present, view_item_list homepage commerce event is fired on change of selected topics (core data save), not page view, as when page appears topics not yet loaded.  