### PR TITLE
Fixes for e-commerce event firing

### DIFF
--- a/Production/govuk_ios/Coordinators/HomeCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/HomeCoordinator.swift
@@ -123,10 +123,12 @@ class HomeCoordinator: TabItemCoordinator {
         return { [weak self] in
             self?.trackWidgetNavigation(text: "EditTopics")
             guard let self = self else { return }
+            self.topicWidgetViewModel.isEditing = true
             let navigationController = UINavigationController()
             let coordinator = self.coordinatorBuilder.editTopics(
                 navigationController: navigationController,
                 didDismissAction: {
+                    self.topicWidgetViewModel.isEditing = false
                     self.root.viewWillReAppear()
                 }
             )
@@ -134,7 +136,7 @@ class HomeCoordinator: TabItemCoordinator {
         }
     }
 
-    private var topicWidgetViewModel: TopicsWidgetViewModel {
+    private lazy var topicWidgetViewModel: TopicsWidgetViewModel = {
         TopicsWidgetViewModel(
             topicsService: topicsService,
             analyticsService: analyticsService,
@@ -142,7 +144,7 @@ class HomeCoordinator: TabItemCoordinator {
             editAction: presentEditTopicsCoordinator,
             allTopicsAction: startAllTopicsCoordinator
         )
-    }
+    }()
 
     private func trackWidgetNavigation(text: String,
                                        external: Bool = false) {

--- a/Production/govuk_ios/ViewControllers/HomeViewController.swift
+++ b/Production/govuk_ios/ViewControllers/HomeViewController.swift
@@ -45,6 +45,11 @@ class HomeViewController: BaseViewController,
         navigationController?.setNavigationBarHidden(true, animated: animated)
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel.trackECommerce()
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Production/govuk_ios/ViewModels/HomeViewModel.swift
+++ b/Production/govuk_ios/ViewModels/HomeViewModel.swift
@@ -83,4 +83,8 @@ struct HomeViewModel {
     private func widgetEnabled(feature: Feature) -> Bool {
         configService.isFeatureEnabled(key: feature)
     }
+
+    func trackECommerce() {
+        topicWidgetViewModel.trackECommerce()
+    }
 }

--- a/Production/govuk_ios/ViewModels/Topics/StepByStepsViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/StepByStepsViewModel.swift
@@ -20,6 +20,8 @@ class StepByStepsViewModel: TopicDetailViewModelInterface {
         self.urlOpener = urlOpener
     }
 
+    var isLoaded: Bool = true
+
     var title: String {
         String.topics.localized("topicDetailStepByStepHeader")
     }
@@ -40,7 +42,6 @@ class StepByStepsViewModel: TopicDetailViewModelInterface {
 
     func trackScreen(screen: TrackableScreen) {
         analyticsService.track(screen: screen)
-        trackEcommerce()
     }
 
     func trackEcommerce() {

--- a/Production/govuk_ios/ViewModels/Topics/TopicDetailViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicDetailViewModel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import GOVKit
 import RecentActivity
 
+// swiftlint:disable:next type_body_length
 class TopicDetailViewModel: TopicDetailViewModelInterface {
     @Published private(set) var sections = [GroupedListSection]()
     @Published private(set) var errorViewModel: AppErrorViewModel?
@@ -16,6 +17,8 @@ class TopicDetailViewModel: TopicDetailViewModelInterface {
     private let urlOpener: URLOpener
     private let subtopicAction: (DisplayableTopic) -> Void
     private let stepByStepAction: ([TopicDetailResponse.Content]) -> Void
+
+    var isLoaded: Bool = false
 
     var title: String {
         topic.title
@@ -64,12 +67,14 @@ class TopicDetailViewModel: TopicDetailViewModelInterface {
     }
 
     private func fetchTopicDetails(topicRef: String) {
+        self.isLoaded = false
         topicsService.fetchDetails(
             ref: topicRef,
             completion: { result in
                 if case let .success(detail) = result {
                     self.topicDetail = detail
                     self.configureSections()
+                    self.isLoaded = true
                 }
                 self.handleError(result.getError())
             }

--- a/Production/govuk_ios/ViewModels/Topics/TopicDetailViewModelInterface.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicDetailViewModelInterface.swift
@@ -4,11 +4,12 @@ import GOVKit
 
 protocol TopicDetailViewModelInterface: ObservableObject {
     var title: String { get }
+    var isLoaded: Bool { get }
     var description: String? { get }
     var sections: [GroupedListSection] { get }
     var errorViewModel: AppErrorViewModel? { get }
-    func trackScreen(screen: TrackableScreen)
     var commerceItems: [TopicCommerceItem] { get set }
+    func trackScreen(screen: TrackableScreen)
     func trackEcommerce()
 }
 

--- a/Production/govuk_ios/ViewModels/Topics/TopicsWidgetViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicsWidgetViewModel.swift
@@ -12,6 +12,8 @@ final class TopicsWidgetViewModel {
     let editAction: () -> Void
     var handleError: ((TopicsServiceError) -> Void)?
     var fetchTopicsError: Bool = false
+    var initialLoadComplete: Bool = false
+    var isEditing: Bool = false
 
     init(topicsService: TopicsServiceInterface,
          analyticsService: AnalyticsServiceInterface,
@@ -72,19 +74,21 @@ final class TopicsWidgetViewModel {
     }
 
     func trackECommerce() {
-        let trackedTopics = displayedTopics
-        var items = [HomeCommerceItem]()
-        trackedTopics.enumerated().forEach { index, topic in
-            let item = HomeCommerceItem(name: topic.title,
-                                        index: index + 1,
-                                        itemId: nil,
-                                        locationId: nil)
-            items.append(item)
+        if !isEditing && initialLoadComplete {
+            let trackedTopics = displayedTopics
+            var items = [HomeCommerceItem]()
+            trackedTopics.enumerated().forEach { index, topic in
+                let item = HomeCommerceItem(name: topic.title,
+                                            index: index + 1,
+                                            itemId: nil,
+                                            locationId: nil)
+                items.append(item)
+            }
+            let event = AppEvent.viewItemList(name: "Homepage",
+                                              id: "Homepage",
+                                              items: items)
+            analyticsService.track(event: event)
         }
-        let event = AppEvent.viewItemList(name: "Homepage",
-                                          id: "Homepage",
-                                          items: items)
-        analyticsService.track(event: event)
     }
 
     func trackECommerceSelection(_ name: String) {

--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -125,7 +125,10 @@ class TopicsWidgetView: UIView {
     private func topicsDidUpdate(notification: Notification) {
         DispatchQueue.main.async {
             self.updateTopics(self.viewModel.displayedTopics)
-            self.viewModel.trackECommerce()
+            if self.viewModel.initialLoadComplete == false {
+                self.viewModel.initialLoadComplete = true
+                self.viewModel.trackECommerce()
+            }
             self.showAllTopicsButton()
             self.titleLabel.text = self.viewModel.widgetTitle
         }

--- a/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/Topics/TopicsWidgetView.swift
@@ -125,10 +125,8 @@ class TopicsWidgetView: UIView {
     private func topicsDidUpdate(notification: Notification) {
         DispatchQueue.main.async {
             self.updateTopics(self.viewModel.displayedTopics)
-            if self.viewModel.initialLoadComplete == false {
-                self.viewModel.initialLoadComplete = true
-                self.viewModel.trackECommerce()
-            }
+            self.viewModel.initialLoadComplete = true
+            self.viewModel.trackECommerce()
             self.showAllTopicsButton()
             self.titleLabel.text = self.viewModel.widgetTitle
         }

--- a/Production/govuk_ios/Views/Topics/TopicDetailView.swift
+++ b/Production/govuk_ios/Views/Topics/TopicDetailView.swift
@@ -48,11 +48,16 @@ struct TopicDetailView<T: TopicDetailViewModelInterface>: View {
         }
         .onAppear {
             viewModel.trackScreen(screen: self)
+            // isLoaded == true on back navigation, otherwise e-commerce
+            // triggered in .onChange
+            if viewModel.isLoaded {
+                viewModel.trackEcommerce()
+            }
         }
-        .onChange(of: viewModel.sections.count) { _ in
-            // Note that this change event does not fire for the Step by step screen
-            // Ecommerce tracking is handled in the trackScreen event in that case
-            viewModel.trackEcommerce()
+        .onChange(of: viewModel.isLoaded) { isLoaded in
+            if isLoaded {
+                viewModel.trackEcommerce()
+            }
         }
     }
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/Topics/TopicsWidgetViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/Topics/TopicsWidgetViewModelTests.swift
@@ -277,6 +277,8 @@ struct TopicsWidgetViewModelTests {
             allTopicsAction: { }
         )
 
+        sut.initialLoadComplete = true
+
         let trackedTopic = try #require(sut.displayedTopics.first?.title)
         sut.trackECommerce()
         #expect(mockAnalyticsService._trackedEvents.count == 1)


### PR DESCRIPTION
Add flags to help track state of topic loading, so that e-commerce events can be fired based on screen appearances.  