### PR TITLE
Updates ContentScrollable to ResetsToDefault

### DIFF
--- a/Production/govuk_ios/Coordinators/HomeCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/HomeCoordinator.swift
@@ -48,12 +48,10 @@ class HomeCoordinator: TabItemCoordinator {
     }
 
     func didReselectTab() {
-        guard let homeViewController = root.viewControllers.first as? ContentScrollable
-        else {
-            return
-        }
+        guard let homeViewController = root.viewControllers.first as? ResetsToDefault
+        else { return }
         if childCoordinators.isEmpty {
-            homeViewController.scrollToTop()
+            homeViewController.resetState()
         }
     }
 

--- a/Production/govuk_ios/Extensions/UIKit/UIViewController+Extensions.swift
+++ b/Production/govuk_ios/Extensions/UIKit/UIViewController+Extensions.swift
@@ -1,8 +1,8 @@
 import Foundation
 import UIKit
 
-protocol ContentScrollable {
-    func scrollToTop()
+protocol ResetsToDefault {
+    func resetState()
 }
 
 extension UIViewController {

--- a/Production/govuk_ios/ViewControllers/HomeContentViewController.swift
+++ b/Production/govuk_ios/ViewControllers/HomeContentViewController.swift
@@ -81,9 +81,7 @@ class HomeContentViewController: BaseViewController,
         }
         stackView.addArrangedSubview(crownLogoImageView)
     }
-}
 
-extension HomeContentViewController: ContentScrollable {
     func scrollToTop() {
         let currentX = scrollView.contentOffset.x
         let topOffset = CGPoint(x: currentX, y: -scrollView.adjustedContentInset.top)

--- a/Production/govuk_ios/ViewControllers/HomeViewController.swift
+++ b/Production/govuk_ios/ViewControllers/HomeViewController.swift
@@ -92,7 +92,7 @@ class HomeViewController: BaseViewController {
         view.backgroundColor = UIColor.govUK.fills.surfaceHomeHeaderBackground
     }
 
-    func displayController(_ content: UIViewController) {
+    private func displayController(_ content: UIViewController) {
         addController(content)
         content.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -190,8 +190,8 @@ extension HomeViewController: UISearchBarDelegate {
     }
 }
 
-extension HomeViewController: ContentScrollable {
-    func scrollToTop() {
+extension HomeViewController: ResetsToDefault {
+    func resetState() {
         searchBar.setShowsCancelButton(false, animated: true)
         searchBar.resignFirstResponder()
         searchBar.text = ""

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/ViewControllers/MockHomeViewController.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/ViewControllers/MockHomeViewController.swift
@@ -2,14 +2,14 @@ import UIKit
 @testable import govuk_ios
 
 class MockHomeViewController: UIViewController,
-                              ContentScrollable {
+                              ResetsToDefault {
 
     override func viewDidLoad() {
         super.viewDidLoad()
     }
     
-    var _didScrollToTop = false
-    func scrollToTop() {
-        _didScrollToTop = true
+    var _hasResetState = false
+    func resetState() {
+        _hasResetState = true
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/HomeCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/HomeCoordinatorTests.swift
@@ -156,7 +156,7 @@ struct HomeCoordinatorTests {
     
     @Test
     @MainActor
-    func didReselectTab_scrollsToTop_whenOnHomeScreen() {
+    func didReselectTab_resetsToDefaultState_whenOnHomeScreen() {
         let mockCoodinatorBuilder = MockCoordinatorBuilder(container: .init())
         let mockViewControllerBuilder = MockViewControllerBuilder()
         let navigationController = UINavigationController()
@@ -178,12 +178,12 @@ struct HomeCoordinatorTests {
         subject.start()
         subject.didReselectTab()
         
-        #expect(homeViewController._didScrollToTop)
+        #expect(homeViewController._hasResetState)
     }
     
     @Test
     @MainActor
-    func didReselectTab_doesNotScrollsToTop_whenOnChildScreen() {
+    func didReselectTab_doesNotResetToDefaultState_whenOnChildScreen() {
         let mockCoodinatorBuilder = MockCoordinatorBuilder(container: .init())
         let mockViewControllerBuilder = MockViewControllerBuilder()
         let navigationController = UINavigationController()
@@ -206,6 +206,6 @@ struct HomeCoordinatorTests {
         subject.start(MockBaseCoordinator())
         subject.didReselectTab()
         
-        #expect(homeViewController._didScrollToTop == false)
+        #expect(homeViewController._hasResetState == false)
     }
 }


### PR DESCRIPTION
As ContentScrollable / scrollToTop doesn't really capture the full responsibilities of the function in HomeViewController, this has been renamed to ResetsToDefault / resetState.

We need the protocol for the HomeCoordinatorTests.