### PR TITLE
govukapp-1295: gray squares when button shapes on

### DIFF
--- a/GOVKit/Sources/GOVKit/SwiftUIViews/AppErrorView.swift
+++ b/GOVKit/Sources/GOVKit/SwiftUIViews/AppErrorView.swift
@@ -52,5 +52,6 @@ public struct AppErrorView: View {
             ? String.common.localized("openWebLinkHint")
             : ""
         )
+        .opacity(viewModel?.buttonTitle == nil ? 0 : 1)
     }
 }

--- a/Production/govuk_ios/ViewControllers/SearchHistoryViewController.swift
+++ b/Production/govuk_ios/ViewControllers/SearchHistoryViewController.swift
@@ -61,11 +61,12 @@ final class SearchHistoryViewController: BaseViewController {
     }()
 
     private lazy var deleteButton: UIButton = {
-        var configuration = UIButton.Configuration.plain()
+        var configuration = UIButton.Configuration.filled()
         configuration.contentInsets = .zero
         configuration.titleAlignment = .trailing
+        configuration.baseForegroundColor = UIColor.govUK.text.link
+        configuration.baseBackgroundColor = .clear
         let button = UIButton(configuration: configuration)
-        button.tintColor = UIColor.govUK.text.link
         button.setTitle(String.search.localized("clearHistoryButtonTitle"), for: .normal)
         button.titleLabel?.font = UIFont.govUK.body
         button.titleLabel?.adjustsFontForContentSizeCategory = true

--- a/Production/govuk_ios/ViewControllers/SearchViewController.swift
+++ b/Production/govuk_ios/ViewControllers/SearchViewController.swift
@@ -21,6 +21,7 @@ class SearchViewController: BaseViewController,
         localView.showsVerticalScrollIndicator = false
         localView.contentInsetAdjustmentBehavior = .always
         localView.backgroundColor = .govUK.fills.surfaceModal
+        localView.isHidden = true
         return localView
     }()
 

--- a/Production/govuk_ios/Views/Search/SearchHistoryCell.swift
+++ b/Production/govuk_ios/Views/Search/SearchHistoryCell.swift
@@ -3,9 +3,10 @@ import UIComponents
 
 class SearchHistoryCell: UITableViewCell {
     private let deleteButton: UIButton = {
-        var buttonConfig = UIButton.Configuration.plain()
+        var buttonConfig = UIButton.Configuration.filled()
         buttonConfig.image = UIImage(systemName: "xmark")
         buttonConfig.baseForegroundColor = UIColor.govUK.text.trailingIcon
+        buttonConfig.baseBackgroundColor = .clear
         buttonConfig.contentInsets = .zero
 
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 12, weight: .semibold)


### PR DESCRIPTION
The gray square was caused by the AppErrorView's action button reacting to buttonShapes being switched on.  As it had no title, only an empty square was visible.  If there is no title, the opacity is set to 0 to hide it.
For searchHistory, use a filled() UIButton.Configuration to prevent a color change when buttonShapes is switched on.