### PR TITLE
govukapp-1296:  Remove button text wrapping

### DIFF
--- a/GOVKit/Sources/GOVKit/Views/Common/TopAlignedBarButtonItem.swift
+++ b/GOVKit/Sources/GOVKit/Views/Common/TopAlignedBarButtonItem.swift
@@ -16,6 +16,7 @@ public class TopAlignedBarButtonItem: UIBarButtonItem {
         )
         actionButton.translatesAutoresizingMaskIntoConstraints = false
         actionButton.titleLabel?.font = UIFont.govUK.body
+        actionButton.titleLabel?.adjustsFontForContentSizeCategory = true
         actionButton.tintColor = tint
         super.init()
         self.customView = createCustomView()


### PR DESCRIPTION
Set adjustsFontForContentSizeCategory = true for TopAlignedBarButtonItems.  This has the effect of making the items adhere to the font metrics for navigation and tool bars, which prevents them from scaling so large they no longer fit within the tool bar.
![simulator_screenshot_9CB8751B-A9E2-4B2B-88A8-50514B0A2358](https://github.com/user-attachments/assets/85e9661b-914f-4782-9c69-638acace2bdc)
