### PR TITLE
GOVUKAPP-1132 App deep links from notification

### DIFF
--- a/Production/govuk_ios/Services/Notifications/NotificationService.swift
+++ b/Production/govuk_ios/Services/Notifications/NotificationService.swift
@@ -8,7 +8,7 @@ import OneSignalFramework
 protocol NotificationServiceInterface: OnboardingSlideProvider {
     func appDidFinishLaunching(launchOptions: [UIApplication.LaunchOptionsKey: Any]?)
     func requestPermissions(completion: (() -> Void)?)
-    func addClickListener(onClick: @escaping (URL) -> Void)
+    func addClickListener(onClickAction: @escaping (URL) -> Void)
     var shouldRequestPermission: Bool { get async }
     var permissionState: NotificationPermissionState { get async }
     var isFeatureEnabled: Bool { get }
@@ -17,7 +17,7 @@ protocol NotificationServiceInterface: OnboardingSlideProvider {
 class NotificationService: NSObject, NotificationServiceInterface, OSNotificationClickListener {
     private var environmentService: AppEnvironmentServiceInterface
     private let notificationCenter: UserNotificationCenterInterface
-    var onClick: ((URL) -> Void)?
+    var onClickAction: ((URL) -> Void)?
 
     init(environmentService: AppEnvironmentServiceInterface,
          notificationCenter: UserNotificationCenterInterface) {
@@ -76,9 +76,9 @@ class NotificationService: NSObject, NotificationServiceInterface, OSNotificatio
         completion(.success(Onboarding.notificationSlides))
     }
 
-    func addClickListener(onClick: @escaping (URL) -> Void) {
+    func addClickListener(onClickAction: @escaping (URL) -> Void) {
         OneSignal.Notifications.addClickListener(self)
-        self.onClick = onClick
+        self.onClickAction = onClickAction
     }
 
     func onClick(event: OSNotificationClickEvent) {
@@ -86,10 +86,9 @@ class NotificationService: NSObject, NotificationServiceInterface, OSNotificatio
     }
 
     func handleAdditionalData(_ additionalData: [AnyHashable: Any]?) {
-        guard let additionalData else { return }
-        guard let deeplinkStr = additionalData["deeplink"] as? String else { return }
-        if let deeplink = URL(string: deeplinkStr) {
-            onClick?(deeplink)
-        }
+        guard let additionalData,
+              let deeplinkStr = additionalData["deeplink"] as? String,
+              let deeplink = URL(string: deeplinkStr) else { return }
+        onClickAction?(deeplink)
     }
 }

--- a/Production/govuk_ios/SupportingFiles/Info.plist
+++ b/Production/govuk_ios/SupportingFiles/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>OneSignal_suppress_launch_urls</key>
+	<true/>
 	<key>BaseURL</key>
 	<string>$(BASE_URL)</string>
 	<key>CFBundleURLTypes</key>

--- a/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
+++ b/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
@@ -31,9 +31,7 @@ class SceneDelegate: UIResponder,
         let url = connectionOptions.urlContexts.first?.url
         coordinator?.start(url: url)
         let notificationService = Container.shared.notificationService.resolve()
-        notificationService.addClickListener { deeplink in
-            self.coordinator?.start(url: deeplink)
-        }
+        notificationService.addClickListener { deeplink in self.coordinator?.start(url: deeplink) }
     }
 
     func scene(_ scene: UIScene,

--- a/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
+++ b/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
@@ -1,10 +1,10 @@
 import Foundation
 import UIKit
+import Factory
 
 class SceneDelegate: UIResponder,
                      UIWindowSceneDelegate {
     var window: UIWindow?
-    @Inject(\.notificationService) private var notificationService: NotificationServiceInterface
 
     private lazy var navigationController: UINavigationController = {
         let controller = UINavigationController()
@@ -30,6 +30,7 @@ class SceneDelegate: UIResponder,
 
         let url = connectionOptions.urlContexts.first?.url
         coordinator?.start(url: url)
+        let notificationService = Container.shared.notificationService.resolve()
         notificationService.addClickListener { deeplink in
             self.coordinator?.start(url: deeplink)
         }

--- a/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
+++ b/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
@@ -4,6 +4,7 @@ import UIKit
 class SceneDelegate: UIResponder,
                      UIWindowSceneDelegate {
     var window: UIWindow?
+    @Inject(\.notificationService) private var notificationService: NotificationServiceInterface
 
     private lazy var navigationController: UINavigationController = {
         let controller = UINavigationController()
@@ -29,6 +30,9 @@ class SceneDelegate: UIResponder,
 
         let url = connectionOptions.urlContexts.first?.url
         coordinator?.start(url: url)
+        notificationService.addClickListener { deeplink in
+            self.coordinator?.start(url: deeplink)
+        }
     }
 
     func scene(_ scene: UIScene,

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/NotificationServiceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/NotificationServiceTests.swift
@@ -120,4 +120,89 @@ class NotificationServiceTests {
         )
         #expect(await sut.permissionState == .notDetermined)
     }
+
+    @Test
+    func addClickListener_assignsOnClick() {
+        let sut = NotificationService(
+            environmentService: MockAppEnvironmentService(),
+            notificationCenter: MockUserNotificationCenter()
+        )
+        let onClick: ((URL) -> Void)? = { url in }
+        sut.addClickListener(
+            onClick: onClick!
+        )
+        #expect(sut.onClick != nil)
+    }
+
+    @Test
+    func handleAdditionalData_whenAdditionalDataIsNil_doesNotCallOnClick() {
+        let sut = NotificationService(
+            environmentService: MockAppEnvironmentService(),
+            notificationCenter: MockUserNotificationCenter()
+        )
+
+        var didOnClick = false
+        sut.onClick = { _ in
+            didOnClick = true
+        }
+
+        let additionalData: [AnyHashable: Any]? = nil
+        sut.handleAdditionalData(additionalData)
+
+        #expect(didOnClick == false)
+    }
+
+    @Test
+    func handleAdditionalData_whenAdditionalDataIsEmpty_doesNotCallOnClick() {
+        let sut = NotificationService(
+            environmentService: MockAppEnvironmentService(),
+            notificationCenter: MockUserNotificationCenter()
+        )
+
+        var didOnClick = false
+        sut.onClick = { _ in
+            didOnClick = true
+        }
+
+        let additionalData: [AnyHashable: Any]? = [:]
+        sut.handleAdditionalData(additionalData)
+
+        #expect(didOnClick == false)
+    }
+
+    @Test
+    func handleAdditionalData_whenAdditionalDataDeeplinkCannotBeParsedToAUrl_doesNotCallOnClick() {
+        let sut = NotificationService(
+            environmentService: MockAppEnvironmentService(),
+            notificationCenter: MockUserNotificationCenter()
+        )
+
+        var didOnClick = false
+        sut.onClick = { _ in
+            didOnClick = true
+        }
+
+        let additionalData: [AnyHashable: Any]? = ["deeplink": ""]
+        sut.handleAdditionalData(additionalData)
+
+        #expect(didOnClick == false)
+    }
+
+    @Test
+    func handleAdditionalData_whenAdditionalDataIsValid_onClickHasTheCorrectUrl() {
+        let sut = NotificationService(
+            environmentService: MockAppEnvironmentService(),
+            notificationCenter: MockUserNotificationCenter()
+        )
+
+        var result: URL?
+        sut.onClick = { url in
+            result = url
+        }
+
+        let additionalData: [AnyHashable: Any]? = ["deeplink": "scheme://host"]
+        sut.handleAdditionalData(additionalData)
+
+        #expect(result?.absoluteString == "scheme://host")
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/NotificationServiceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/NotificationServiceTests.swift
@@ -127,76 +127,76 @@ class NotificationServiceTests {
             environmentService: MockAppEnvironmentService(),
             notificationCenter: MockUserNotificationCenter()
         )
-        let onClick: ((URL) -> Void)? = { url in }
+        let onClickAction: ((URL) -> Void)? = { _ in }
         sut.addClickListener(
-            onClick: onClick!
+            onClickAction: onClickAction!
         )
-        #expect(sut.onClick != nil)
+        #expect(sut.onClickAction != nil)
     }
 
     @Test
-    func handleAdditionalData_whenAdditionalDataIsNil_doesNotCallOnClick() {
+    func handleAdditionalData_whenAdditionalDataIsNil_doesNotCallOnClickAction() {
         let sut = NotificationService(
             environmentService: MockAppEnvironmentService(),
             notificationCenter: MockUserNotificationCenter()
         )
 
-        var didOnClick = false
-        sut.onClick = { _ in
-            didOnClick = true
+        var didOnClickAction = false
+        sut.onClickAction = { _ in
+            didOnClickAction = true
         }
 
         let additionalData: [AnyHashable: Any]? = nil
         sut.handleAdditionalData(additionalData)
 
-        #expect(didOnClick == false)
+        #expect(didOnClickAction == false)
     }
 
     @Test
-    func handleAdditionalData_whenAdditionalDataIsEmpty_doesNotCallOnClick() {
+    func handleAdditionalData_whenAdditionalDataIsEmpty_doesNotCallOnClickAction() {
         let sut = NotificationService(
             environmentService: MockAppEnvironmentService(),
             notificationCenter: MockUserNotificationCenter()
         )
 
-        var didOnClick = false
-        sut.onClick = { _ in
-            didOnClick = true
+        var didOnClickAction = false
+        sut.onClickAction = { _ in
+            didOnClickAction = true
         }
 
         let additionalData: [AnyHashable: Any]? = [:]
         sut.handleAdditionalData(additionalData)
 
-        #expect(didOnClick == false)
+        #expect(didOnClickAction == false)
     }
 
     @Test
-    func handleAdditionalData_whenAdditionalDataDeeplinkCannotBeParsedToAUrl_doesNotCallOnClick() {
+    func handleAdditionalData_whenAdditionalDataDeeplinkCannotBeParsedToAUrl_doesNotCallOnClickAction() {
         let sut = NotificationService(
             environmentService: MockAppEnvironmentService(),
             notificationCenter: MockUserNotificationCenter()
         )
 
-        var didOnClick = false
-        sut.onClick = { _ in
-            didOnClick = true
+        var didOnClickAction = false
+        sut.onClickAction = { _ in
+            didOnClickAction = true
         }
 
         let additionalData: [AnyHashable: Any]? = ["deeplink": ""]
         sut.handleAdditionalData(additionalData)
 
-        #expect(didOnClick == false)
+        #expect(didOnClickAction == false)
     }
 
     @Test
-    func handleAdditionalData_whenAdditionalDataIsValid_onClickHasTheCorrectUrl() {
+    func handleAdditionalData_whenAdditionalDataIsValid_onClickActionHasTheCorrectUrl() {
         let sut = NotificationService(
             environmentService: MockAppEnvironmentService(),
             notificationCenter: MockUserNotificationCenter()
         )
 
         var result: URL?
-        sut.onClick = { url in
+        sut.onClickAction = { url in
             result = url
         }
 

--- a/Tests/govuk_ios/shared/Mocks/Services/MockNotificationService.swift
+++ b/Tests/govuk_ios/shared/Mocks/Services/MockNotificationService.swift
@@ -42,4 +42,9 @@ class MockNotificationService: NotificationServiceInterface {
     var isFeatureEnabled: Bool {
         _stubbedIsFetureEnabled
     }
+
+    var _onClick: ((URL) -> Void)?
+    func addClickListener(onClick: @escaping (URL) -> Void) {
+        _onClick = onClick
+    }
 }

--- a/Tests/govuk_ios/shared/Mocks/Services/MockNotificationService.swift
+++ b/Tests/govuk_ios/shared/Mocks/Services/MockNotificationService.swift
@@ -43,8 +43,8 @@ class MockNotificationService: NotificationServiceInterface {
         _stubbedIsFetureEnabled
     }
 
-    var _onClick: ((URL) -> Void)?
-    func addClickListener(onClick: @escaping (URL) -> Void) {
-        _onClick = onClick
+    var _onClickAction: ((URL) -> Void)?
+    func addClickListener(onClickAction: @escaping (URL) -> Void) {
+        _onClickAction = onClickAction
     }
 }


### PR DESCRIPTION
- Add click listener to notification clicks. 
- Handle notifications additional data.
- Prevent launch urls being opened from One Signal notifications.

[Jira link](https://govukverify.atlassian.net/browse/GOVUKAPP-1132)