### PR TITLE
govukapp-1557: unsuccessful sign out

### DIFF
--- a/Production/govuk_ios/Builders/CoordinatorBuilder.swift
+++ b/Production/govuk_ios/Builders/CoordinatorBuilder.swift
@@ -268,7 +268,7 @@ class CoordinatorBuilder {
     }
 
     func signedOut(navigationController: UINavigationController,
-                   completion: @escaping () -> Void) -> BaseCoordinator {
+                   completion: @escaping (Bool) -> Void) -> BaseCoordinator {
         SignedOutCoordinator(
             navigationController: navigationController,
             viewControllerBuilder: ViewControllerBuilder(),

--- a/Production/govuk_ios/Builders/ViewControllerBuilder.swift
+++ b/Production/govuk_ios/Builders/ViewControllerBuilder.swift
@@ -138,7 +138,7 @@ class ViewControllerBuilder {
     @MainActor
     func signOutConfirmation(authenticationService: AuthenticationServiceInterface,
                              analyticsService: AnalyticsServiceInterface,
-                             completion: @escaping () -> Void) -> UIViewController {
+                             completion: @escaping (Bool) -> Void) -> UIViewController {
         let viewModel = SignOutConfirmationViewModel(
             authenticationService: authenticationService,
             analyticsService: analyticsService,

--- a/Production/govuk_ios/Coordinators/AppCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/AppCoordinator.swift
@@ -145,8 +145,14 @@ class AppCoordinator: BaseCoordinator {
     private func startSignedOutCoordinator(url: URL?) {
         let coordinator = coordinatorBuilder.signedOut(
             navigationController: root,
-            completion: { [weak self] in
-                self?.startTabs(url: nil)
+            completion: { [weak self] signedIn in
+                if signedIn {
+                    self?.startTabs(
+                        url: URL(string: "govuk://settings/settings")
+                    )
+                } else {
+                    self?.startAuthenticationOnboardingCoordinator(url: nil)
+                }
             }
         )
         start(coordinator, url: url)

--- a/Production/govuk_ios/Coordinators/SettingsCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/SettingsCoordinator.swift
@@ -47,8 +47,7 @@ class SettingsCoordinator: TabItemCoordinator {
 
     override func childDidFinish(_ child: BaseCoordinator) {
         super.childDidFinish(child)
-        if child is SignOutConfirmationCoordinator,
-           !authenticationService.isSignedIn {
+        if child is SignOutConfirmationCoordinator {
             finish()
         }
     }

--- a/Production/govuk_ios/Coordinators/SignOutConfirmationCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/SignOutConfirmationCoordinator.swift
@@ -21,15 +21,17 @@ final class SignOutConfirmationCoordinator: BaseCoordinator {
         let viewController = viewControllerBuilder.signOutConfirmation(
             authenticationService: authenticationService,
             analyticsService: analyticsService,
-            completion: { [weak self] in
-                self?.dismiss()
+            completion: { [weak self] didAttemptSignOut in
+                self?.dismiss(didAttemptSignOut)
             }
         )
         set([viewController])
     }
 
-    private func dismiss() {
-        finish()
-        root.dismiss(animated: authenticationService.isSignedIn)
+    private func dismiss(_ didAttemptSignOut: Bool) {
+        if didAttemptSignOut {
+            finish()
+        }
+        root.dismiss(animated: true)
     }
 }

--- a/Production/govuk_ios/Coordinators/SignedOutCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/SignedOutCoordinator.swift
@@ -6,13 +6,13 @@ class SignedOutCoordinator: BaseCoordinator {
     private let viewControllerBuilder: ViewControllerBuilder
     private let authenticationService: AuthenticationServiceInterface
     private let analyticsService: AnalyticsServiceInterface
-    private let completion: () -> Void
+    private let completion: (Bool) -> Void
 
     init(navigationController: UINavigationController,
          viewControllerBuilder: ViewControllerBuilder,
          authenticationService: AuthenticationServiceInterface,
          analyticsService: AnalyticsServiceInterface,
-         completion: @escaping () -> Void) {
+         completion: @escaping (Bool) -> Void) {
         self.viewControllerBuilder = viewControllerBuilder
         self.authenticationService = authenticationService
         self.analyticsService = analyticsService
@@ -25,7 +25,8 @@ class SignedOutCoordinator: BaseCoordinator {
             authenticationService: authenticationService,
             analyticsService: analyticsService,
             completion: { [weak self] in
-                self?.completion()
+                guard let self = self else { return }
+                self.completion(self.authenticationService.isSignedIn)
             }
         )
         set(viewController, animated: false)

--- a/Production/govuk_ios/Coordinators/TabCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/TabCoordinator.swift
@@ -45,8 +45,7 @@ class TabCoordinator: BaseCoordinator,
 
     override func childDidFinish(_ child: BaseCoordinator) {
         super.childDidFinish(child)
-        if let child = child as? SettingsCoordinator,
-           !child.authenticationService.isSignedIn {
+        if child is SettingsCoordinator {
             finish()
         }
     }

--- a/Production/govuk_ios/Resources/Strings/SignOut.xcstrings
+++ b/Production/govuk_ios/Resources/Strings/SignOut.xcstrings
@@ -1,6 +1,50 @@
 {
   "sourceLanguage" : "en-GB",
   "strings" : {
+    "signedOutButtonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in with GOV.UK One Login"
+          }
+        }
+      }
+    },
+    "signedOutErrorButtonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go back to settings"
+          }
+        }
+      }
+    },
+    "signedOutErrorSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again later.\n\nIf you need to sign out right now, you can delete the app from your phone."
+          }
+        }
+      }
+    },
+    "signedOutErrorTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There was a problem signing you out"
+          }
+        }
+      }
+    },
     "signedOutSubtitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -19,17 +63,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "You’ve signed out"
-          }
-        }
-      }
-    },
-    "signInButtonTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in with GOV.UK One Login"
           }
         }
       }

--- a/Production/govuk_ios/Services/AuthenticationService.swift
+++ b/Production/govuk_ios/Services/AuthenticationService.swift
@@ -59,9 +59,19 @@ class AuthenticationService: AuthenticationServiceInterface {
     }
 
     func signOut() {
-        secureStoreService.deleteItem(itemName: "refreshToken")
-        try? secureStoreService.delete()
-        setTokens()
+        do {
+            try secureStoreService.delete()
+            secureStoreService.deleteItem(itemName: "refreshToken")
+            setTokens()
+        } catch {
+            #if targetEnvironment(simulator)
+            // secure store deletion will always fail on simulator
+            // as secure enclave unavailable.
+            secureStoreService.deleteItem(itemName: "refreshToken")
+            setTokens()
+            #endif
+            return
+        }
     }
 
     func encryptRefreshToken() {

--- a/Production/govuk_ios/ViewModels/SignOutConfirmationViewModel.swift
+++ b/Production/govuk_ios/ViewModels/SignOutConfirmationViewModel.swift
@@ -11,11 +11,11 @@ final class SignOutConfirmationViewModel {
 
     private let analyticsService: AnalyticsServiceInterface
     private let authenticationService: AuthenticationServiceInterface
-    private let completion: () -> Void
+    private let completion: (Bool) -> Void
 
     init(authenticationService: AuthenticationServiceInterface,
          analyticsService: AnalyticsServiceInterface,
-         completion: @escaping () -> Void) {
+         completion: @escaping (Bool) -> Void) {
         self.authenticationService = authenticationService
         self.analyticsService = analyticsService
         self.completion = completion
@@ -28,7 +28,7 @@ final class SignOutConfirmationViewModel {
             action: { [weak self] in
                 self?.authenticationService.signOut()
                 self?.trackNavigationEvent(buttonTitle)
-                self?.completion()
+                self?.completion(true)
             }
         )
     }
@@ -39,7 +39,7 @@ final class SignOutConfirmationViewModel {
             localisedTitle: buttonTitle,
             action: { [weak self] in
                 self?.trackNavigationEvent(buttonTitle)
-                self?.completion()
+                self?.completion(false)
             }
         )
     }

--- a/Production/govuk_ios/ViewModels/SignedOutViewModel.swift
+++ b/Production/govuk_ios/ViewModels/SignedOutViewModel.swift
@@ -1,11 +1,8 @@
-import Foundation
+import SwiftUI
 import GOVKit
 import UIComponents
 
 final class SignedOutViewModel {
-    let title: String = String.signOut.localized("signedOutTitle")
-    let subTitle: String = String.signOut.localized("signedOutSubtitle")
-
     private let analyticsService: AnalyticsServiceInterface
     private let authenticationService: AuthenticationServiceInterface
     private let completion: () -> Void
@@ -18,13 +15,37 @@ final class SignedOutViewModel {
         self.completion = completion
     }
 
-    var signInButtonViewModel: GOVUKButton.ButtonViewModel {
-        let buttonTitle = String.signOut.localized("signInButtonTitle")
+    var title: String {
+        authenticationService.isSignedIn ?
+        String.signOut.localized("signedOutErrorTitle") :
+        String.signOut.localized("signedOutTitle")
+    }
+
+    var subtitle: String {
+        authenticationService.isSignedIn ?
+        String.signOut.localized("signedOutErrorSubtitle") :
+        String.signOut.localized("signedOutSubtitle")
+    }
+
+    var buttonTitle: String {
+        authenticationService.isSignedIn ?
+        String.signOut.localized("signedOutErrorButtonTitle") :
+        String.signOut.localized("signedOutButtonTitle")
+    }
+
+    var warningImage: Image? {
+        authenticationService.isSignedIn ?
+        Image(systemName: "exclamationmark.circle") :
+        nil
+    }
+
+    var signedOutButtonViewModel: GOVUKButton.ButtonViewModel {
         return GOVUKButton.ButtonViewModel(
             localisedTitle: buttonTitle,
             action: { [weak self] in
-                self?.trackNavigationEvent(buttonTitle)
-                self?.completion()
+                guard let self = self else { return }
+                self.trackNavigationEvent(self.buttonTitle)
+                self.completion()
             }
         )
     }

--- a/Production/govuk_ios/Views/SignOut/SignedOutView.swift
+++ b/Production/govuk_ios/Views/SignOut/SignedOutView.swift
@@ -26,7 +26,7 @@ struct SignedOutView: View {
                 .ignoresSafeArea()
             SwiftUIButton(
                 .primary,
-                viewModel: viewModel.signInButtonViewModel
+                viewModel: viewModel.signedOutButtonViewModel
             )
             .frame(minHeight: 44, idealHeight: 44)
             .padding(16)
@@ -37,6 +37,10 @@ struct SignedOutView: View {
 
     private var infoView: some View {
         VStack {
+            if let image = viewModel.warningImage {
+                image
+                    .font(Font.system(size: 107, weight: .light))
+            }
             Text(viewModel.title)
                 .fontWeight(.bold)
                 .foregroundColor(Color(UIColor.govUK.text.primary))
@@ -44,7 +48,7 @@ struct SignedOutView: View {
                 .multilineTextAlignment(.center)
                 .accessibilityAddTraits(.isHeader)
                 .padding(.bottom, 16)
-            Text(viewModel.subTitle)
+            Text(viewModel.subtitle)
                 .foregroundColor(Color(UIColor.govUK.text.primary))
                 .font(Font.govUK.body)
                 .multilineTextAlignment(.center)

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.SignedOutViewControllerSnapshotTests/test_loadInNavigationController_with_error_dark_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.SignedOutViewControllerSnapshotTests/test_loadInNavigationController_with_error_dark_rendersCorrectly@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ab48a500a4e38bb687e68d099ac320c787ac4ddbe5b99f10689ee97f0ca298e
+size 143389

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.SignedOutViewControllerSnapshotTests/test_loadInNavigationController_with_error_light_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.SignedOutViewControllerSnapshotTests/test_loadInNavigationController_with_error_light_rendersCorrectly@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:446b5c4d6b534a372437d74599154eda71f154dc39220d74aff615c296a6cc05
+size 135106

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignOutConfirmationViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignOutConfirmationViewControllerSnapshotTests.swift
@@ -12,7 +12,7 @@ class SignOutConfirmationViewControllerSnapshotTests: SnapshotTestCase {
     func test_loadInNavigationController_light_rendersCorrectly() {
         let viewModel = SignOutConfirmationViewModel(authenticationService: MockAuthenticationService(),
                                                      analyticsService: MockAnalyticsService(),
-                                                     completion: { })
+                                                     completion: { _ in })
         let signOutConfirmationView = SignOutConfirmationView(
             viewModel: viewModel
         )
@@ -30,7 +30,7 @@ class SignOutConfirmationViewControllerSnapshotTests: SnapshotTestCase {
     func test_loadInNavigationController_dark_rendersCorrectly() {
         let viewModel = SignOutConfirmationViewModel(authenticationService: MockAuthenticationService(),
                                                      analyticsService: MockAnalyticsService(),
-                                                     completion: { })
+                                                     completion: { _ in })
         let signOutConfirmationView = SignOutConfirmationView(
             viewModel: viewModel
         )

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignedOutViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignedOutViewControllerSnapshotTests.swift
@@ -40,4 +40,40 @@ class SignedOutViewControllerSnapshotTests: SnapshotTestCase {
             prefersLargeTitles: true
         )
     }
+
+    func test_loadInNavigationController_with_error_light_rendersCorrectly() {
+        let mockAuthenticationService = MockAuthenticationService()
+        mockAuthenticationService._stubbedIsSignedIn = true
+        let viewModel = SignedOutViewModel(authenticationService: mockAuthenticationService,
+                                           analyticsService: MockAnalyticsService(),
+                                           completion: { })
+        let signedOutView = SignedOutView(viewModel: viewModel)
+        let hostingViewController =  HostingViewController(
+            rootView: signedOutView,
+            statusBarStyle: .darkContent
+        )
+        VerifySnapshotInNavigationController(
+            viewController: hostingViewController,
+            mode: .light,
+            prefersLargeTitles: true
+        )
+    }
+
+    func test_loadInNavigationController_with_error_dark_rendersCorrectly() {
+        let mockAuthenticationService = MockAuthenticationService()
+        mockAuthenticationService._stubbedIsSignedIn = true
+        let viewModel = SignedOutViewModel(authenticationService: mockAuthenticationService,
+                                           analyticsService: MockAnalyticsService(),
+                                           completion: { })
+        let signedOutView = SignedOutView(viewModel: viewModel)
+        let hostingViewController =  HostingViewController(
+            rootView: signedOutView,
+            statusBarStyle: .darkContent
+        )
+        VerifySnapshotInNavigationController(
+            viewController: hostingViewController,
+            mode: .dark,
+            prefersLargeTitles: true
+        )
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockCoordinatorBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockCoordinatorBuilder.swift
@@ -164,10 +164,10 @@ class MockCoordinatorBuilder: CoordinatorBuilder {
         _stubbedSignOutConfirmationCoordinator ?? MockBaseCoordinator()
     }
 
-    var _receivedSignedOutCompletion: (() -> Void)?
+    var _receivedSignedOutCompletion: ((Bool) -> Void)?
     var _stubbedSignedOutCoordinator: MockBaseCoordinator?
     override func signedOut(navigationController: UINavigationController,
-                            completion: @escaping () -> Void) -> BaseCoordinator {
+                            completion: @escaping (Bool) -> Void) -> BaseCoordinator {
         _receivedSignedOutCompletion = completion
         return _stubbedSignedOutCoordinator ?? MockBaseCoordinator()
     }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockCoordinatorBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockCoordinatorBuilder.swift
@@ -12,7 +12,7 @@ extension CoordinatorBuilder {
 
 class MockCoordinatorBuilder: CoordinatorBuilder {
 
-    var _stubbedTabCoordinator: MockBaseCoordinator?
+    var _stubbedTabCoordinator: BaseCoordinator?
     var _receivedTabNavigationController: UINavigationController?
     override func tab(navigationController: UINavigationController) -> BaseCoordinator {
         _receivedTabNavigationController = navigationController

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
@@ -111,16 +111,20 @@ class MockViewControllerBuilder: ViewControllerBuilder {
     }
 
     var _stubbedSignOutConfirmationViewController: UIViewController?
+    var _receivedSignOutConfirmationCompletion: ((Bool) -> Void)?
     override func signOutConfirmation(authenticationService: any AuthenticationServiceInterface,
                                       analyticsService: any AnalyticsServiceInterface,
                                       completion: @escaping (Bool) -> Void) -> UIViewController {
-        _stubbedSignOutConfirmationViewController ?? UIViewController()
+        _receivedSignOutConfirmationCompletion = completion
+        return _stubbedSignOutConfirmationViewController ?? UIViewController()
     }
 
+    var _receivedSignedOutCompletion: (() -> Void)?
     var _stubbedSignedOutViewController: UIViewController?
     override func signedOut(authenticationService: AuthenticationServiceInterface,
                             analyticsService: AnalyticsServiceInterface,
                             completion: @escaping () -> Void) -> UIViewController {
-        _stubbedSignedOutViewController ?? UIViewController()
+        _receivedSignedOutCompletion = completion
+        return _stubbedSignedOutViewController ?? UIViewController()
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
@@ -113,7 +113,7 @@ class MockViewControllerBuilder: ViewControllerBuilder {
     var _stubbedSignOutConfirmationViewController: UIViewController?
     override func signOutConfirmation(authenticationService: any AuthenticationServiceInterface,
                                       analyticsService: any AnalyticsServiceInterface,
-                                      completion: @escaping () -> Void) -> UIViewController {
+                                      completion: @escaping (Bool) -> Void) -> UIViewController {
         _stubbedSignOutConfirmationViewController ?? UIViewController()
     }
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
@@ -275,7 +275,7 @@ struct CoordinatorBuilderTests {
         let mockNavigationController = MockNavigationController()
         let coordinator = subject.signedOut(
             navigationController: mockNavigationController,
-            completion: { }
+            completion: { _ in }
         )
 
         #expect(coordinator is SignedOutCoordinator)

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
@@ -190,7 +190,7 @@ struct ViewControllerBuilderTests {
         let result = subject.signOutConfirmation(
             authenticationService:MockAuthenticationService(),
             analyticsService: MockAnalyticsService(),
-            completion: { }
+            completion: { _ in }
         )
         let rootView = (result as? HostingViewController<SignOutConfirmationView>)?.rootView
         #expect(rootView != nil)

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/SignOutConfirmationCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/SignOutConfirmationCoordinatorTests.swift
@@ -6,7 +6,7 @@ struct SignOutConfirmationCoordinatorTests {
 
     @Test
     @MainActor
-    func start_setsSignOutConfirmationView() throws {
+    func start_setsSignOutConfirmationView() {
         let mockViewControllerBuilder = MockViewControllerBuilder()
         let navigationController = UINavigationController()
         let expectedViewController = UIViewController()
@@ -22,5 +22,59 @@ struct SignOutConfirmationCoordinatorTests {
         sut.start()
 
         #expect(navigationController.viewControllers.first == expectedViewController)
+    }
+
+    @Test
+    @MainActor
+    func attemptingSignout_callsFinish() async {
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let mockNavigationController = MockNavigationController()
+        let mockCoordinator = MockBaseCoordinator()
+        let expectedViewController = UIViewController()
+
+        mockViewControllerBuilder._stubbedSignOutConfirmationViewController = expectedViewController
+
+
+        var sut: SignOutConfirmationCoordinator!
+        _ = await withCheckedContinuation { continuation in
+            sut = SignOutConfirmationCoordinator(
+                navigationController: mockNavigationController,
+                viewControllerBuilder: mockViewControllerBuilder,
+                authenticationService: MockAuthenticationService(),
+                analyticsService: MockAnalyticsService()
+            )
+            mockCoordinator.start(sut)
+            continuation.resume()
+        }
+
+        mockViewControllerBuilder._receivedSignOutConfirmationCompletion?(true)
+        #expect(mockCoordinator._childDidFinishReceivedChild == sut)
+    }
+
+    @Test
+    @MainActor
+    func cancellingSignout_doesNotCallFinish() async {
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let mockNavigationController = MockNavigationController()
+        let mockCoordinator = MockBaseCoordinator()
+        let expectedViewController = UIViewController()
+
+        mockViewControllerBuilder._stubbedSignOutConfirmationViewController = expectedViewController
+
+
+        var sut: SignOutConfirmationCoordinator!
+        _ = await withCheckedContinuation { continuation in
+            sut = SignOutConfirmationCoordinator(
+                navigationController: mockNavigationController,
+                viewControllerBuilder: mockViewControllerBuilder,
+                authenticationService: MockAuthenticationService(),
+                analyticsService: MockAnalyticsService()
+            )
+            mockCoordinator.start(sut)
+            continuation.resume()
+        }
+
+        mockViewControllerBuilder._receivedSignOutConfirmationCompletion?(false)
+        #expect(mockCoordinator._childDidFinishReceivedChild == nil)
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/SignedOutCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/SignedOutCoordinatorTests.swift
@@ -25,4 +25,30 @@ struct SignedOutCoordinatorTests {
 
         #expect(navigationController.viewControllers.first == expectedViewController)
     }
+
+    @Test
+    func completionCalled_withAuthStatus() throws {
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let mockAuthenticationService = MockAuthenticationService()
+        mockAuthenticationService._stubbedIsSignedIn = true
+        let navigationController = UINavigationController()
+        let expectedViewController = UIViewController()
+        mockViewControllerBuilder._stubbedSignedOutViewController = expectedViewController
+
+        var isAuthenticated = false
+        let sut = SignedOutCoordinator(
+            navigationController: navigationController,
+            viewControllerBuilder: mockViewControllerBuilder,
+            authenticationService: mockAuthenticationService,
+            analyticsService: MockAnalyticsService(),
+            completion: { signedIn in
+                isAuthenticated = signedIn
+            }
+        )
+
+        sut.start()
+        mockViewControllerBuilder
+            ._receivedSignedOutCompletion?()
+        #expect(isAuthenticated)
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/SignedOutCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/SignedOutCoordinatorTests.swift
@@ -18,7 +18,7 @@ struct SignedOutCoordinatorTests {
             viewControllerBuilder: mockViewControllerBuilder,
             authenticationService: MockAuthenticationService(),
             analyticsService: MockAnalyticsService(),
-            completion: { }
+            completion: { _ in }
         )
 
         sut.start()

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/TabCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/TabCoordinatorTests.swift
@@ -238,4 +238,39 @@ struct TabCoordinatorTests {
 
         #expect(mockHomeCoordinator._didReselectTab == didReselectTab)
     }
+
+    @Test
+    func finishingSettingsTab_finishesTabCoordinator() throws {
+        let mockAnalyticsService = MockAnalyticsService()
+        let mockCoordinatorBuilder = MockCoordinatorBuilder.mock
+
+        let mockHomeCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedHomeCoordinator = mockHomeCoordinator
+        let mockAuthenticationService = MockAuthenticationService()
+        mockAuthenticationService._stubbedIsSignedIn = false
+
+        let settingsCoordinator = SettingsCoordinator(
+            navigationController: MockNavigationController(),
+            viewControllerBuilder: MockViewControllerBuilder(),
+            deeplinkStore: DeeplinkDataStore(routes: [], root: UIViewController()),
+            analyticsService: MockAnalyticsService(),
+            coordinatorBuilder: mockCoordinatorBuilder,
+            deviceInformationProvider: MockDeviceInformationProvider(),
+            authenticationService: mockAuthenticationService,
+            notificationService: MockNotificationService()
+        )
+        mockCoordinatorBuilder._stubbedSettingsCoordinator = settingsCoordinator
+
+        let navigationController = UINavigationController()
+        let subject = TabCoordinator(
+            coordinatorBuilder: mockCoordinatorBuilder,
+            navigationController: navigationController,
+            analyticsService: mockAnalyticsService
+        )
+
+        subject.start(url: nil)
+        #expect(subject.childCoordinators.count == 2)
+        settingsCoordinator.finish()
+        #expect(subject.childCoordinators.count == 1)
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/SignOutConfirmationViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/SignOutConfirmationViewModelTests.swift
@@ -14,7 +14,7 @@ struct SignOutConfirmationViewModelTests {
         let sut = SignOutConfirmationViewModel(
             authenticationService: mockAuthenticationService,
             analyticsService: mockAnalyticsService,
-            completion: {
+            completion: { _ in
                 didCallCompletion = true
             }
         )
@@ -34,7 +34,7 @@ struct SignOutConfirmationViewModelTests {
         let sut = SignOutConfirmationViewModel(
             authenticationService: mockAuthenticationService,
             analyticsService: mockAnalyticsService,
-            completion: {
+            completion: { _ in 
                 didCallCompletion = true
             }
         )
@@ -53,7 +53,7 @@ struct SignOutConfirmationViewModelTests {
         let sut = SignOutConfirmationViewModel(
             authenticationService: mockAuthenticationService,
             analyticsService: mockAnalyticsService,
-            completion: { }
+            completion: { _ in }
         )
 
         sut.signOutButtonViewModel.action()
@@ -70,7 +70,7 @@ struct SignOutConfirmationViewModelTests {
         let sut = SignOutConfirmationViewModel(
             authenticationService: mockAuthenticationService,
             analyticsService: mockAnalyticsService,
-            completion: { }
+            completion: { _ in }
         )
 
         sut.cancelButtonViewModel.action()

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/SignedOutViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/SignedOutViewModelTests.swift
@@ -18,9 +18,9 @@ struct SignedOutViewModelTests {
             }
         )
 
-        sut.signInButtonViewModel.action()
+        sut.signedOutButtonViewModel.action()
 
         #expect(didCallCompletion)
-        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == String.signOut.localized("signInButtonTitle"))
+        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == String.signOut.localized("signedOutButtonTitle"))
     }
 }


### PR DESCRIPTION
Enhance signed out view to allow error display if sign out fails.
Refactor coordination to handle sign out cancellation, sign out success, and sign out failure scenarios.
