### PR TITLE
govukapp-1555 sign in error

### DIFF
--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -265,7 +265,7 @@
 		D090467A2DBBC1AC0096EE66 /* TokenExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09046742DBBC1AC0096EE66 /* TokenExtractor.swift */; };
 		D090467C2DBBC1AC0096EE66 /* IdTokenPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09046702DBBC1AC0096EE66 /* IdTokenPayload.swift */; };
 		D090467F2DBBC1ED0096EE66 /* JWTKit in Frameworks */ = {isa = PBXBuildFile; productRef = D090467E2DBBC1ED0096EE66 /* JWTKit */; };
-		D09046812DBFD8480096EE66 /* SignedOutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09046802DBFD8480096EE66 /* SignedOutView.swift */; };
+		D09046812DBFD8480096EE66 /* AuthenticationInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09046802DBFD8480096EE66 /* AuthenticationInfoView.swift */; };
 		D09046832DBFD9430096EE66 /* SignedOutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09046822DBFD9370096EE66 /* SignedOutViewModel.swift */; };
 		D09046872DBFDF5D0096EE66 /* SignedOutCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09046862DBFDF5D0096EE66 /* SignedOutCoordinator.swift */; };
 		D093BA632CB0499A004F489B /* EditTopicsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093BA622CB0499A004F489B /* EditTopicsView.swift */; };
@@ -291,6 +291,7 @@
 		D0EB04842D37F34200B310D8 /* GOV.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = D0EB04812D37F34200B310D8 /* GOV.xcdatamodeld */; };
 		D0EBFBCE2D109B51000A3151 /* GOVKit in Frameworks */ = {isa = PBXBuildFile; productRef = D0EBFBCD2D109B51000A3151 /* GOVKit */; };
 		D0EBFBD22D11C0E7000A3151 /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EBFBD12D11C0E7000A3151 /* AnalyticsService.swift */; };
+		D0EC94C52DCBA5F700A9707E /* AuthenticationInfoViewModelInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EC94C42DCBA5E000A9707E /* AuthenticationInfoViewModelInterface.swift */; };
 		D0F5FF7E2D64D22400C3BF51 /* AppEvent+ECommerce.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0F5FF7D2D64D22400C3BF51 /* AppEvent+ECommerce.swift */; };
 /* End PBXBuildFile section */
 
@@ -598,7 +599,7 @@
 		D08AA4252DB950F2002E9C78 /* SignOut.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = SignOut.xcstrings; sourceTree = "<group>"; };
 		D09046702DBBC1AC0096EE66 /* IdTokenPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenPayload.swift; sourceTree = "<group>"; };
 		D09046742DBBC1AC0096EE66 /* TokenExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenExtractor.swift; sourceTree = "<group>"; };
-		D09046802DBFD8480096EE66 /* SignedOutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedOutView.swift; sourceTree = "<group>"; };
+		D09046802DBFD8480096EE66 /* AuthenticationInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationInfoView.swift; sourceTree = "<group>"; };
 		D09046822DBFD9370096EE66 /* SignedOutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedOutViewModel.swift; sourceTree = "<group>"; };
 		D09046862DBFDF5D0096EE66 /* SignedOutCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedOutCoordinator.swift; sourceTree = "<group>"; };
 		D093BA622CB0499A004F489B /* EditTopicsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsView.swift; sourceTree = "<group>"; };
@@ -626,6 +627,7 @@
 		D0EB04832D37F34200B310D8 /* GOV_v2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = GOV_v2.xcdatamodel; sourceTree = "<group>"; };
 		D0EBFBCC2D0C9653000A3151 /* GOVKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = GOVKit; sourceTree = "<group>"; };
 		D0EBFBD12D11C0E7000A3151 /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
+		D0EC94C42DCBA5E000A9707E /* AuthenticationInfoViewModelInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationInfoViewModelInterface.swift; sourceTree = "<group>"; };
 		D0F5FF7D2D64D22400C3BF51 /* AppEvent+ECommerce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppEvent+ECommerce.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1000,6 +1002,7 @@
 		5D41DB5E2C0875460011E691 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				D0EC94C42DCBA5E000A9707E /* AuthenticationInfoViewModelInterface.swift */,
 				169842D92DB0003C00E3EA66 /* LocalAuthenticationOnboardingViewModel.swift */,
 				3D7E2D132C81DB2D0016BEEC /* AnalyticsConsentContainerViewModel.swift */,
 				3D9C933F2CB0176A00EFA337 /* AppForcedUpdateContainerViewModel.swift */,
@@ -1536,7 +1539,7 @@
 			isa = PBXGroup;
 			children = (
 				D08A9A832DB92A3E002E9C78 /* SignOutConfirmationView.swift */,
-				D09046802DBFD8480096EE66 /* SignedOutView.swift */,
+				D09046802DBFD8480096EE66 /* AuthenticationInfoView.swift */,
 			);
 			path = SignOut;
 			sourceTree = "<group>";
@@ -1967,7 +1970,7 @@
 				5DD09EC82C9ADB8500494550 /* SearchService.swift in Sources */,
 				4EB7D8512DB85A33002B6765 /* LocalAuthorityServiceCoordinator.swift in Sources */,
 				D0D9CFD52D302F2A0051EDDD /* SearchHistoryRepository.swift in Sources */,
-				D09046812DBFD8480096EE66 /* SignedOutView.swift in Sources */,
+				D09046812DBFD8480096EE66 /* AuthenticationInfoView.swift in Sources */,
 				D093BA632CB0499A004F489B /* EditTopicsView.swift in Sources */,
 				D05AF4DC2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift in Sources */,
 				5DD4CB082D95483100459FB5 /* ActivityItem.swift in Sources */,
@@ -2106,6 +2109,7 @@
 				4E038AB92DB8F502005DFA53 /* LocalAuthorityPostcodeEntryViewModel.swift in Sources */,
 				16D0D0432CC6819C00944D79 /* TopicTableViewCell.swift in Sources */,
 				D06EB96C2CA6F71E007EA081 /* TopicCard.swift in Sources */,
+				D0EC94C52DCBA5F700A9707E /* AuthenticationInfoViewModelInterface.swift in Sources */,
 				D0D9CFD72D3030640051EDDD /* SearchHistoryViewController.swift in Sources */,
 				5DA6E5332C47BD2700D41263 /* DeeplinkRouteProvider.swift in Sources */,
 				5DFDEBF12CEE396D00F7A365 /* UserProperty+Convenience.swift in Sources */,

--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -292,6 +292,8 @@
 		D0EBFBCE2D109B51000A3151 /* GOVKit in Frameworks */ = {isa = PBXBuildFile; productRef = D0EBFBCD2D109B51000A3151 /* GOVKit */; };
 		D0EBFBD22D11C0E7000A3151 /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EBFBD12D11C0E7000A3151 /* AnalyticsService.swift */; };
 		D0EC94C52DCBA5F700A9707E /* AuthenticationInfoViewModelInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EC94C42DCBA5E000A9707E /* AuthenticationInfoViewModelInterface.swift */; };
+		D0EC94C72DCBAEE400A9707E /* SignInErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EC94C62DCBAEE400A9707E /* SignInErrorViewModel.swift */; };
+		D0EC94C92DCBC65000A9707E /* SignInErrorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EC94C82DCBC65000A9707E /* SignInErrorCoordinator.swift */; };
 		D0F5FF7E2D64D22400C3BF51 /* AppEvent+ECommerce.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0F5FF7D2D64D22400C3BF51 /* AppEvent+ECommerce.swift */; };
 /* End PBXBuildFile section */
 
@@ -628,6 +630,8 @@
 		D0EBFBCC2D0C9653000A3151 /* GOVKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = GOVKit; sourceTree = "<group>"; };
 		D0EBFBD12D11C0E7000A3151 /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
 		D0EC94C42DCBA5E000A9707E /* AuthenticationInfoViewModelInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationInfoViewModelInterface.swift; sourceTree = "<group>"; };
+		D0EC94C62DCBAEE400A9707E /* SignInErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInErrorViewModel.swift; sourceTree = "<group>"; };
+		D0EC94C82DCBC65000A9707E /* SignInErrorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInErrorCoordinator.swift; sourceTree = "<group>"; };
 		D0F5FF7D2D64D22400C3BF51 /* AppEvent+ECommerce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppEvent+ECommerce.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -667,6 +671,7 @@
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SearchViewControllerSnapshotTests.swift,
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SettingsViewControllerSnapshotTests.swift,
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignedOutViewControllerSnapshotTests.swift,
+				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignInErrorViewControllerSnapshotTests.swift,
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignOutConfirmationViewControllerSnapshotTests.swift,
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/StoredLocalAuthorityWidgetViewSnapshotTests.swift,
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/TopicDetailViewSnapshotTests.swift,
@@ -704,6 +709,7 @@
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SearchViewControllerSnapshotTests.swift,
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SettingsViewControllerSnapshotTests.swift,
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignedOutViewControllerSnapshotTests.swift,
+				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignInErrorViewControllerSnapshotTests.swift,
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignOutConfirmationViewControllerSnapshotTests.swift,
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/StoredLocalAuthorityWidgetViewSnapshotTests.swift,
 				govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/TopicDetailViewSnapshotTests.swift,
@@ -1026,6 +1032,7 @@
 				4E038AB62DB8E567005DFA53 /* LocalAuthorityWidgetViewModel.swift */,
 				4E038AB82DB8F502005DFA53 /* LocalAuthorityPostcodeEntryViewModel.swift */,
 				4EEC0F2F2DBB7B9100D745F2 /* StoredLocalAuthorityWidgetViewModel.swift */,
+				D0EC94C62DCBAEE400A9707E /* SignInErrorViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1212,6 +1219,7 @@
 				4E4089872DBBEF78003ECB3B /* EditLocalAuthorityCoordinator.swift */,
 				D08A9A7F2DB9286D002E9C78 /* SignOutConfirmationCoordinator.swift */,
 				D09046862DBFDF5D0096EE66 /* SignedOutCoordinator.swift */,
+				D0EC94C82DCBC65000A9707E /* SignInErrorCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -1898,6 +1906,7 @@
 				16FCDE782DC4E39A000E870D /* TokenRefreshResponse.swift in Sources */,
 				5D66D1882CBFC15000006723 /* AppEvent+Search.swift in Sources */,
 				4EF407562CE2796900D654FC /* UIButton+Extensions.swift in Sources */,
+				D0EC94C72DCBAEE400A9707E /* SignInErrorViewModel.swift in Sources */,
 				164091FA2DA3F4A600E3BE99 /* AuthenticationCoordinator.swift in Sources */,
 				5DE2BBBC2C982593003116B6 /* Bundle+Extensions.swift in Sources */,
 				4EEC0F342DBB7CDA00D745F2 /* StoredLocalAuthorityCardView.swift in Sources */,
@@ -2021,6 +2030,7 @@
 				D0F5FF7E2D64D22400C3BF51 /* AppEvent+ECommerce.swift in Sources */,
 				D04C542C2D7081CC0070EE79 /* TopicCommerceItem.swift in Sources */,
 				5D0BD45B2C9B206F00220625 /* JSONDecoder+Extensions.swift in Sources */,
+				D0EC94C92DCBC65000A9707E /* SignInErrorCoordinator.swift in Sources */,
 				4EFE22A52D0CD0D500136D56 /* RegexRedactor.swift in Sources */,
 				169842DA2DB0004800E3EA66 /* LocalAuthenticationOnboardingViewModel.swift in Sources */,
 				D028CCF62CB9619B00742620 /* Topic.swift in Sources */,

--- a/Production/govuk_ios/Builders/CoordinatorBuilder.swift
+++ b/Production/govuk_ios/Builders/CoordinatorBuilder.swift
@@ -240,12 +240,15 @@ class CoordinatorBuilder {
     }
 
     func authentication(navigationController: UINavigationController,
-                        completionAction: @escaping () -> Void) -> BaseCoordinator {
+                        completionAction: @escaping () -> Void,
+                        handleError: @escaping (AuthenticationError) -> Void) -> BaseCoordinator {
         AuthenticationCoordinator(
             navigationController: navigationController,
             authenticationService: container.authenticationService.resolve(),
             localAuthenticationService: container.localAuthenticationService.resolve(),
-            completionAction: completionAction
+            coordinatorBuilder: self,
+            completionAction: completionAction,
+            handleError: handleError
         )
     }
 
@@ -286,6 +289,16 @@ class CoordinatorBuilder {
             navigationController: navigationController,
             viewControllerBuilder: ViewControllerBuilder(),
             authenticationService: container.authenticationService.resolve(),
+            analyticsService: container.analyticsService.resolve(),
+            completion: completion
+        )
+    }
+
+    func signInError(navigationController: UINavigationController,
+                     completion: @escaping () -> Void) -> BaseCoordinator {
+        SignInErrorCoordinator(
+            navigationController: navigationController,
+            viewControllerBuilder: ViewControllerBuilder(),
             analyticsService: container.analyticsService.resolve(),
             completion: completion
         )

--- a/Production/govuk_ios/Builders/ViewControllerBuilder.swift
+++ b/Production/govuk_ios/Builders/ViewControllerBuilder.swift
@@ -158,7 +158,7 @@ class ViewControllerBuilder {
             analyticsService: analyticsService,
             completion: completion
         )
-        let view = SignedOutView(viewModel: viewModel)
+        let view = AuthenticationInfoView(viewModel: viewModel)
         let viewController = HostingViewController(rootView: view)
         return viewController
     }

--- a/Production/govuk_ios/Builders/ViewControllerBuilder.swift
+++ b/Production/govuk_ios/Builders/ViewControllerBuilder.swift
@@ -164,6 +164,18 @@ class ViewControllerBuilder {
     }
 
     @MainActor
+    func signInError(analyticsService: AnalyticsServiceInterface,
+                     completion: @escaping () -> Void) -> UIViewController {
+        let viewModel = SignInErrorViewModel(
+            analyticsService: analyticsService,
+            completion: completion
+        )
+        let view = AuthenticationInfoView(viewModel: viewModel)
+        let viewController = HostingViewController(rootView: view)
+        return viewController
+    }
+
+    @MainActor
     // swiftlint:disable:next function_parameter_count
     func topicDetail(topic: DisplayableTopic,
                      topicsService: TopicsServiceInterface,

--- a/Production/govuk_ios/Coordinators/AuthenticationCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/AuthenticationCoordinator.swift
@@ -1,18 +1,25 @@
 import Foundation
 import UIKit
+import Authentication
 
 class AuthenticationCoordinator: BaseCoordinator {
     private let authenticationService: AuthenticationServiceInterface
     private let localAuthenticationService: LocalAuthenticationServiceInterface
+    private let coordinatorBuilder: CoordinatorBuilder
     private let completionAction: () -> Void
+    private let handleError: (AuthenticationError) -> Void
 
     init(navigationController: UINavigationController,
          authenticationService: AuthenticationServiceInterface,
          localAuthenticationService: LocalAuthenticationServiceInterface,
-         completionAction: @escaping () -> Void) {
+         coordinatorBuilder: CoordinatorBuilder,
+         completionAction: @escaping () -> Void,
+         handleError: @escaping (AuthenticationError) -> Void) {
         self.authenticationService = authenticationService
         self.localAuthenticationService = localAuthenticationService
+        self.coordinatorBuilder = coordinatorBuilder
         self.completionAction = completionAction
+        self.handleError = handleError
         super.init(navigationController: navigationController)
     }
 
@@ -37,7 +44,9 @@ class AuthenticationCoordinator: BaseCoordinator {
                 self.completionAction()
             }
         case .failure(let error):
-            print("\(error)")
+            DispatchQueue.main.async {
+                self.handleError(error)
+            }
         }
     }
 

--- a/Production/govuk_ios/Coordinators/AuthenticationOnboardingCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/AuthenticationOnboardingCoordinator.swift
@@ -34,7 +34,7 @@ class AuthenticationOnboardingCoordinator: BaseCoordinator {
         setOnboarding()
     }
 
-    private func setOnboarding() {
+    private func setOnboarding(_ animated: Bool = true) {
         let onboardingModule = Onboarding(
             slideProvider: authenticationOnboardingService,
             analyticsService: analyticsService,
@@ -47,7 +47,10 @@ class AuthenticationOnboardingCoordinator: BaseCoordinator {
                 self?.finishCoordination()
             }
         )
-        set(onboardingModule.viewController)
+        set(
+            onboardingModule.viewController,
+            animated: animated
+        )
     }
 
     private func finishCoordination() {
@@ -59,9 +62,23 @@ class AuthenticationOnboardingCoordinator: BaseCoordinator {
     private func authenticateAction() async {
         let authenticationCoordinator = coordinatorBuilder.authentication(
             navigationController: navigationController,
-            completionAction: completionAction
+            completionAction: completionAction,
+            handleError: showError
         )
-        authenticationCoordinator.start()
+        start(authenticationCoordinator)
+    }
+
+    func showError(_ error: AuthenticationError) {
+        guard case .loginFlow(.userCancelled) = error else {
+            let errorCoordinator = coordinatorBuilder.signInError(
+                navigationController: root,
+                completion: { [weak self] in
+                    self?.setOnboarding(false)
+                }
+            )
+            start(errorCoordinator)
+            return
+        }
     }
 
     private var shouldSkipOnboarding: Bool {

--- a/Production/govuk_ios/Coordinators/SignInErrorCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/SignInErrorCoordinator.swift
@@ -1,0 +1,34 @@
+import UIKit
+import Foundation
+import GOVKit
+
+class SignInErrorCoordinator: BaseCoordinator {
+    private let viewControllerBuilder: ViewControllerBuilder
+    private let analyticsService: AnalyticsServiceInterface
+    private let completion: () -> Void
+
+    init(navigationController: UINavigationController,
+         viewControllerBuilder: ViewControllerBuilder,
+         analyticsService: AnalyticsServiceInterface,
+         completion: @escaping () -> Void) {
+        self.viewControllerBuilder = viewControllerBuilder
+        self.analyticsService = analyticsService
+        self.completion = completion
+        super.init(navigationController: navigationController)
+    }
+
+    override func start(url: URL?) {
+        let viewController = viewControllerBuilder.signInError(
+            analyticsService: analyticsService,
+            completion: { [weak self] in
+                self?.finish()
+            }
+        )
+        set(viewController, animated: false)
+    }
+
+    override func finish() {
+        super.finish()
+        self.completion()
+    }
+}

--- a/Production/govuk_ios/Resources/Strings/SignOut.xcstrings
+++ b/Production/govuk_ios/Resources/Strings/SignOut.xcstrings
@@ -67,6 +67,39 @@
         }
       }
     },
+    "signInErrorSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try to sign in again"
+          }
+        }
+      }
+    },
+    "signInErrorTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There was a problem signing you in"
+          }
+        }
+      }
+    },
+    "signInRetryButtonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go back and try again"
+          }
+        }
+      }
+    },
     "signOutBody" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Production/govuk_ios/ViewModels/AuthenticationInfoViewModelInterface.swift
+++ b/Production/govuk_ios/ViewModels/AuthenticationInfoViewModelInterface.swift
@@ -1,0 +1,21 @@
+import Foundation
+import SwiftUI
+import GOVKit
+import UIComponents
+
+protocol AuthenticationInfoViewModelInterface {
+    var analyticsService: AnalyticsServiceInterface { get }
+    var title: String { get }
+    var subtitle: String { get }
+    var buttonTitle: String { get }
+    var buttonViewModel: GOVUKButton.ButtonViewModel { get }
+    var image: Image? { get }
+    var trackingName: String { get }
+    var trackingTitle: String { get }
+}
+
+extension AuthenticationInfoViewModelInterface {
+    func trackScreen(screen: TrackableScreen) {
+        analyticsService.track(screen: screen)
+    }
+}

--- a/Production/govuk_ios/ViewModels/SignInErrorViewModel.swift
+++ b/Production/govuk_ios/ViewModels/SignInErrorViewModel.swift
@@ -1,0 +1,51 @@
+import Foundation
+import GOVKit
+import UIComponents
+import SwiftUI
+
+final class SignInErrorViewModel: AuthenticationInfoViewModelInterface {
+    let analyticsService: AnalyticsServiceInterface
+    private let completion: () -> Void
+
+    init(analyticsService: AnalyticsServiceInterface,
+         completion: @escaping () -> Void) {
+        self.analyticsService = analyticsService
+        self.completion = completion
+    }
+
+    var title: String {
+        String.signOut.localized("signInErrorTitle")
+    }
+
+    var subtitle: String {
+        String.signOut.localized("signInErrorSubtitle")
+    }
+
+    var buttonTitle: String {
+        String.signOut.localized("signInRetryButtonTitle")
+    }
+
+    var buttonViewModel: GOVUKButton.ButtonViewModel {
+        GOVUKButton.ButtonViewModel(
+            localisedTitle: buttonTitle) { [weak self] in
+                guard let self = self else { return }
+                self.trackNavigationEvent(self.buttonTitle)
+                self.completion()
+            }
+    }
+
+    var image: Image? {
+        Image(systemName: "exclamationmark.circle")
+    }
+
+    var trackingName: String { "Sign In Error" }
+    var trackingTitle: String { title }
+
+    private func trackNavigationEvent(_ title: String) {
+        let event = AppEvent.buttonNavigation(
+            text: title,
+            external: false
+        )
+        analyticsService.track(event: event)
+    }
+}

--- a/Production/govuk_ios/ViewModels/SignedOutViewModel.swift
+++ b/Production/govuk_ios/ViewModels/SignedOutViewModel.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import GOVKit
 import UIComponents
 
-final class SignedOutViewModel {
-    private let analyticsService: AnalyticsServiceInterface
+final class SignedOutViewModel: AuthenticationInfoViewModelInterface {
+    let analyticsService: AnalyticsServiceInterface
     private let authenticationService: AuthenticationServiceInterface
     private let completion: () -> Void
 
@@ -33,13 +33,13 @@ final class SignedOutViewModel {
         String.signOut.localized("signedOutButtonTitle")
     }
 
-    var warningImage: Image? {
+    var image: Image? {
         authenticationService.isSignedIn ?
         Image(systemName: "exclamationmark.circle") :
         nil
     }
 
-    var signedOutButtonViewModel: GOVUKButton.ButtonViewModel {
+    var buttonViewModel: GOVUKButton.ButtonViewModel {
         return GOVUKButton.ButtonViewModel(
             localisedTitle: buttonTitle,
             action: { [weak self] in
@@ -50,15 +50,19 @@ final class SignedOutViewModel {
         )
     }
 
+    var trackingName: String {
+        "Signed Out"
+    }
+
+    var trackingTitle: String {
+        title
+    }
+
     private func trackNavigationEvent(_ title: String) {
         let event = AppEvent.buttonNavigation(
             text: title,
             external: false
         )
         analyticsService.track(event: event)
-    }
-
-    func trackScreen(screen: TrackableScreen) {
-        analyticsService.track(screen: screen)
     }
 }

--- a/Production/govuk_ios/ViewModels/SignedOutViewModel.swift
+++ b/Production/govuk_ios/ViewModels/SignedOutViewModel.swift
@@ -50,13 +50,8 @@ final class SignedOutViewModel: AuthenticationInfoViewModelInterface {
         )
     }
 
-    var trackingName: String {
-        "Signed Out"
-    }
-
-    var trackingTitle: String {
-        title
-    }
+    var trackingName: String { "Signed Out" }
+    var trackingTitle: String { title }
 
     private func trackNavigationEvent(_ title: String) {
         let event = AppEvent.buttonNavigation(

--- a/Production/govuk_ios/Views/SignOut/AuthenticationInfoView.swift
+++ b/Production/govuk_ios/Views/SignOut/AuthenticationInfoView.swift
@@ -2,13 +2,11 @@ import SwiftUI
 import GOVKit
 import UIComponents
 
-import Factory
-
-struct SignedOutView: View {
+struct AuthenticationInfoView: View {
     @Environment(\.verticalSizeClass) var verticalSizeClass
-    private var viewModel: SignedOutViewModel
+    private var viewModel: AuthenticationInfoViewModelInterface
 
-    init(viewModel: SignedOutViewModel) {
+    init(viewModel: AuthenticationInfoViewModelInterface) {
         self.viewModel = viewModel
     }
 
@@ -26,18 +24,21 @@ struct SignedOutView: View {
                 .ignoresSafeArea()
             SwiftUIButton(
                 .primary,
-                viewModel: viewModel.signedOutButtonViewModel
+                viewModel: viewModel.buttonViewModel
             )
             .frame(minHeight: 44, idealHeight: 44)
             .padding(16)
             .ignoresSafeArea()
         }
         .navigationBarHidden(true)
+        .onAppear {
+            viewModel.trackScreen(screen: self)
+        }
     }
 
     private var infoView: some View {
         VStack {
-            if let image = viewModel.warningImage {
+            if let image = viewModel.image {
                 image
                     .font(Font.system(size: 107, weight: .light))
             }
@@ -54,5 +55,15 @@ struct SignedOutView: View {
                 .multilineTextAlignment(.center)
         }
         .padding(.horizontal, 16)
+    }
+}
+
+extension AuthenticationInfoView: TrackableScreen {
+    var trackingName: String {
+        viewModel.trackingName
+    }
+
+    var trackingTitle: String? {
+        viewModel.trackingTitle
     }
 }

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.SignInErrorViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.SignInErrorViewControllerSnapshotTests/test_loadInNavigationController_dark_rendersCorrectly@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0a7927851a5751aef5166a0030140884a4a594067f92a9a2cc3fa7a78b60b78
+size 124701

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.SignInErrorViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.SignInErrorViewControllerSnapshotTests/test_loadInNavigationController_light_rendersCorrectly@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dafdc4568138f2aa63435481f7cc71fda7ff34771562532191a8407e09e6343
+size 116356

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignInErrorViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignInErrorViewControllerSnapshotTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import XCTest
+import UIKit
+import GOVKit
+
+@testable import GOVKitTestUtilities
+@testable import govuk_ios
+
+@MainActor
+class SignInErrorViewControllerSnapshotTests: SnapshotTestCase {
+
+    func test_loadInNavigationController_light_rendersCorrectly() {
+        let viewModel = SignInErrorViewModel(
+            analyticsService: MockAnalyticsService(),
+            completion: { })
+        let signInErrorView = AuthenticationInfoView(viewModel: viewModel)
+        let hostingViewController =  HostingViewController(
+            rootView: signInErrorView,
+            statusBarStyle: .darkContent
+        )
+        VerifySnapshotInNavigationController(
+            viewController: hostingViewController,
+            mode: .light,
+            prefersLargeTitles: true
+        )
+    }
+
+    func test_loadInNavigationController_dark_rendersCorrectly() {
+        let viewModel = SignInErrorViewModel(
+            analyticsService: MockAnalyticsService(),
+            completion: { })
+        let signInErrorView = AuthenticationInfoView(viewModel: viewModel)
+        let hostingViewController =  HostingViewController(
+            rootView: signInErrorView,
+            statusBarStyle: .darkContent
+        )
+        VerifySnapshotInNavigationController(
+            viewController: hostingViewController,
+            mode: .dark,
+            prefersLargeTitles: true
+        )
+    }
+
+}

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignedOutViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/SignedOutViewControllerSnapshotTests.swift
@@ -13,7 +13,7 @@ class SignedOutViewControllerSnapshotTests: SnapshotTestCase {
         let viewModel = SignedOutViewModel(authenticationService: MockAuthenticationService(),
                                            analyticsService: MockAnalyticsService(),
                                            completion: { })
-        let signedOutView = SignedOutView(viewModel: viewModel)
+        let signedOutView = AuthenticationInfoView(viewModel: viewModel)
         let hostingViewController =  HostingViewController(
             rootView: signedOutView,
             statusBarStyle: .darkContent
@@ -29,7 +29,7 @@ class SignedOutViewControllerSnapshotTests: SnapshotTestCase {
         let viewModel = SignedOutViewModel(authenticationService: MockAuthenticationService(),
                                            analyticsService: MockAnalyticsService(),
                                            completion: { })
-        let signedOutView = SignedOutView(viewModel: viewModel)
+        let signedOutView = AuthenticationInfoView(viewModel: viewModel)
         let hostingViewController =  HostingViewController(
             rootView: signedOutView,
             statusBarStyle: .darkContent
@@ -47,7 +47,7 @@ class SignedOutViewControllerSnapshotTests: SnapshotTestCase {
         let viewModel = SignedOutViewModel(authenticationService: mockAuthenticationService,
                                            analyticsService: MockAnalyticsService(),
                                            completion: { })
-        let signedOutView = SignedOutView(viewModel: viewModel)
+        let signedOutView = AuthenticationInfoView(viewModel: viewModel)
         let hostingViewController =  HostingViewController(
             rootView: signedOutView,
             statusBarStyle: .darkContent
@@ -65,7 +65,7 @@ class SignedOutViewControllerSnapshotTests: SnapshotTestCase {
         let viewModel = SignedOutViewModel(authenticationService: mockAuthenticationService,
                                            analyticsService: MockAnalyticsService(),
                                            completion: { })
-        let signedOutView = SignedOutView(viewModel: viewModel)
+        let signedOutView = AuthenticationInfoView(viewModel: viewModel)
         let hostingViewController =  HostingViewController(
             rootView: signedOutView,
             statusBarStyle: .darkContent

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockCoordinatorBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockCoordinatorBuilder.swift
@@ -144,10 +144,13 @@ class MockCoordinatorBuilder: CoordinatorBuilder {
     }
 
     var _receivedAuthenticationCompletion: (() -> Void)?
+    var _receivedAuthenticationHandleError: ((AuthenticationError) -> Void)?
     var _stubbedAuthenticationCoordinator: MockBaseCoordinator?
     override func authentication(navigationController: UINavigationController,
-                                 completionAction: @escaping () -> Void) -> BaseCoordinator {
+                                 completionAction: @escaping () -> Void,
+                                 handleError: @escaping (AuthenticationError) -> Void) -> BaseCoordinator {
         _receivedAuthenticationCompletion = completionAction
+        _receivedAuthenticationHandleError = handleError
         return _stubbedAuthenticationCoordinator ?? MockBaseCoordinator()
     }
 
@@ -178,5 +181,13 @@ class MockCoordinatorBuilder: CoordinatorBuilder {
                             completion: @escaping (Bool) -> Void) -> BaseCoordinator {
         _receivedSignedOutCompletion = completion
         return _stubbedSignedOutCoordinator ?? MockBaseCoordinator()
+    }
+
+    var _receivedSignInErrorCompletion: (() -> Void)?
+    var _stubbedSignInErrorCoordinator: MockBaseCoordinator?
+    override func signInError(navigationController: UINavigationController,
+                            completion: @escaping () -> Void) -> BaseCoordinator {
+        _receivedSignInErrorCompletion = completion
+        return _stubbedSignInErrorCoordinator ?? MockBaseCoordinator()
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
@@ -127,4 +127,13 @@ class MockViewControllerBuilder: ViewControllerBuilder {
         _receivedSignedOutCompletion = completion
         return _stubbedSignedOutViewController ?? UIViewController()
     }
+
+    var _receivedSignInErrorCompletion: (() -> Void)?
+    var _stubbedSignInErrorViewController: UIViewController?
+    override func signInError(analyticsService: any AnalyticsServiceInterface,
+                              completion: @escaping () -> Void) -> UIViewController {
+        _receivedSignInErrorCompletion = completion
+        return _stubbedSignInErrorViewController ?? UIViewController()
+
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
@@ -242,7 +242,8 @@ struct CoordinatorBuilderTests {
         let mockNavigationController = MockNavigationController()
         let coordinator = subject.authentication(
             navigationController: mockNavigationController,
-            completionAction: { }
+            completionAction: { },
+            handleError: { _ in }
         )
 
         #expect(coordinator is AuthenticationCoordinator)
@@ -279,6 +280,18 @@ struct CoordinatorBuilderTests {
         )
 
         #expect(coordinator is SignedOutCoordinator)
+    }
+
+    @Test
+    func signInError_returnsExpectedResult() {
+        let subject = CoordinatorBuilder(container: Container())
+        let mockNavigationController = MockNavigationController()
+        let coordinator = subject.signInError(
+            navigationController: mockNavigationController,
+            completion: { }
+        )
+
+        #expect(coordinator is SignInErrorCoordinator)
     }
 
     func webView_returnsExpectedResult() {

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
@@ -207,4 +207,15 @@ struct ViewControllerBuilderTests {
         let rootView = (result as? HostingViewController<AuthenticationInfoView>)?.rootView
         #expect(rootView != nil)
     }
+
+    @Test
+    func signInError_returnsExpectedResult() {
+        let subject = ViewControllerBuilder()
+        let result = subject.signInError(
+            analyticsService: MockAnalyticsService(),
+            completion: { }
+        )
+        let rootView = (result as? HostingViewController<AuthenticationInfoView>)?.rootView
+        #expect(rootView != nil)
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
@@ -204,7 +204,7 @@ struct ViewControllerBuilderTests {
             analyticsService: MockAnalyticsService(),
             completion: { }
         )
-        let rootView = (result as? HostingViewController<SignedOutView>)?.rootView
+        let rootView = (result as? HostingViewController<AuthenticationInfoView>)?.rootView
         #expect(rootView != nil)
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/AppCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/AppCoordinatorTests.swift
@@ -30,7 +30,7 @@ struct AppCoordinatorTests {
     @Test
     @MainActor
     func start_secondLaunch_startsTabCoordinator() {
-        let mockCoodinatorBuilder = MockCoordinatorBuilder.mock
+        let mockCoordinatorBuilder = MockCoordinatorBuilder.mock
         let mockNavigationController = UINavigationController()
         let mockLaunchCoodinator = MockBaseCoordinator(
             navigationController: mockNavigationController
@@ -38,11 +38,11 @@ struct AppCoordinatorTests {
         let mockTabCoodinator = MockBaseCoordinator(
             navigationController: mockNavigationController
         )
-        mockCoodinatorBuilder._stubbedLaunchCoordinator = mockLaunchCoodinator
-        mockCoodinatorBuilder._stubbedTabCoordinator = mockTabCoodinator
+        mockCoordinatorBuilder._stubbedLaunchCoordinator = mockLaunchCoodinator
+        mockCoordinatorBuilder._stubbedTabCoordinator = mockTabCoodinator
 
         let subject = AppCoordinator(
-            coordinatorBuilder: mockCoodinatorBuilder,
+            coordinatorBuilder: mockCoordinatorBuilder,
             navigationController: mockNavigationController
         )
 
@@ -57,18 +57,18 @@ struct AppCoordinatorTests {
             topicResult: .success(TopicResponseItem.arrangeMultiple),
             appVersionProvider: MockAppVersionProvider()
         )
-        mockCoodinatorBuilder._receivedLaunchCompletion?(launchResult)
+        mockCoordinatorBuilder._receivedLaunchCompletion?(launchResult)
         // This is in order of launch
-        mockCoodinatorBuilder._receivedAppForcedUpdateDismissAction?()
-        mockCoodinatorBuilder._receivedAppUnavailableDismissAction?()
-        mockCoodinatorBuilder._receivedAppRecommendUpdateDismissAction?()
-        mockCoodinatorBuilder._receivedReauthenticationCompletion?()
-        mockCoodinatorBuilder._receivedAnalyticsConsentDismissAction?()
-        mockCoodinatorBuilder._receivedOnboardingDismissAction?()
-        mockCoodinatorBuilder._receivedAuthenticationOnboardingCompletion?()
-        mockCoodinatorBuilder._receivedLocalAuthenticationOnboardingCompletion?()
-        mockCoodinatorBuilder._receivedTopicOnboardingDidDismissAction?()
-        mockCoodinatorBuilder._receivedNotificationOnboardingCompletion?()
+        mockCoordinatorBuilder._receivedAppForcedUpdateDismissAction?()
+        mockCoordinatorBuilder._receivedAppUnavailableDismissAction?()
+        mockCoordinatorBuilder._receivedAppRecommendUpdateDismissAction?()
+        mockCoordinatorBuilder._receivedReauthenticationCompletion?()
+        mockCoordinatorBuilder._receivedAnalyticsConsentDismissAction?()
+        mockCoordinatorBuilder._receivedOnboardingDismissAction?()
+        mockCoordinatorBuilder._receivedAuthenticationOnboardingCompletion?()
+        mockCoordinatorBuilder._receivedLocalAuthenticationOnboardingCompletion?()
+        mockCoordinatorBuilder._receivedTopicOnboardingDidDismissAction?()
+        mockCoordinatorBuilder._receivedNotificationOnboardingCompletion?()
 
         #expect(mockTabCoodinator._startCalled)
 
@@ -130,6 +130,7 @@ struct AppCoordinatorTests {
         mockCoordinatorBuilder._receivedAppForcedUpdateDismissAction?()
         mockCoordinatorBuilder._receivedAppUnavailableDismissAction?()
         mockCoordinatorBuilder._receivedAppRecommendUpdateDismissAction?()
+        mockCoordinatorBuilder._receivedReauthenticationCompletion?()
         mockCoordinatorBuilder._receivedAnalyticsConsentDismissAction?()
         mockCoordinatorBuilder._receivedOnboardingDismissAction?()
         mockCoordinatorBuilder._receivedAuthenticationOnboardingCompletion?()

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/AuthenticationCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/AuthenticationCoordinatorTests.swift
@@ -35,7 +35,9 @@ class AuthenticationCoordinatorTests {
                 navigationController: mockNavigationController,
                 authenticationService: mockAuthenticationService,
                 localAuthenticationService: mockLocalAuthenticationService,
-                completionAction: { continuation.resume(returning: true) }
+                coordinatorBuilder: MockCoordinatorBuilder.mock,
+                completionAction: { continuation.resume(returning: true) },
+                handleError: { _ in }
             )
             sut.start(url: nil)
         }
@@ -72,7 +74,9 @@ class AuthenticationCoordinatorTests {
                 navigationController: mockNavigationController,
                 authenticationService: mockAuthenticationService,
                 localAuthenticationService: mockLocalAuthenticationService,
-                completionAction: { continuation.resume(returning: true) }
+                coordinatorBuilder: MockCoordinatorBuilder.mock,
+                completionAction: { continuation.resume(returning: true) },
+                handleError: { _ in }
             )
             sut.start(url: nil)
         }
@@ -109,7 +113,9 @@ class AuthenticationCoordinatorTests {
                 navigationController: mockNavigationController,
                 authenticationService: mockAuthenticationService,
                 localAuthenticationService: mockLocalAuthenticationService,
-                completionAction: { continuation.resume(returning: true) }
+                coordinatorBuilder: MockCoordinatorBuilder.mock,
+                completionAction: { continuation.resume(returning: true) },
+                handleError: { _ in }
             )
             sut.start(url: nil)
         }
@@ -146,7 +152,9 @@ class AuthenticationCoordinatorTests {
                 navigationController: mockNavigationController,
                 authenticationService: mockAuthenticationService,
                 localAuthenticationService: mockLocalAuthenticationService,
-                completionAction: { continuation.resume(returning: true) }
+                coordinatorBuilder: MockCoordinatorBuilder.mock,
+                completionAction: { continuation.resume(returning: true) },
+                handleError: { _ in }
             )
             sut.start(url: nil)
         }
@@ -183,13 +191,49 @@ class AuthenticationCoordinatorTests {
                 navigationController: mockNavigationController,
                 authenticationService: mockAuthenticationService,
                 localAuthenticationService: mockLocalAuthenticationService,
-                completionAction: { continuation.resume(returning: true) }
+                coordinatorBuilder: MockCoordinatorBuilder.mock,
+                completionAction: { continuation.resume(returning: true) },
+                handleError: { _ in }
             )
             sut.start(url: nil)
         }
 
         #expect(mockAuthenticationService._encryptRefreshTokenCallSuccess)
         #expect(completion)
+    }
+
+    @Test @MainActor
+    func authenticationFailure_callsHandleError() async {
+        let mockAuthenticationService = MockAuthenticationService()
+        let mockLocalAuthenticationService = MockLocalAuthenticationService()
+        let mockNavigationController =  MockNavigationController()
+
+        mockLocalAuthenticationService._stubbedCanEvaluatePasscodePolicy = true
+        mockAuthenticationService.authenticationOnboardingFlowSeen = true
+        mockAuthenticationService.isLocalAuthenticationSkipped = false
+        mockAuthenticationService._stubbedAuthenticationResult = .failure(.genericError)
+        let newWindow = UIWindow(frame: UIScreen.main.bounds)
+        newWindow.rootViewController = mockNavigationController
+        newWindow.makeKeyAndVisible()
+
+        var authError: AuthenticationError?
+        let completion = await withCheckedContinuation { continuation in
+            let sut = AuthenticationCoordinator(
+                navigationController: mockNavigationController,
+                authenticationService: mockAuthenticationService,
+                localAuthenticationService: mockLocalAuthenticationService,
+                coordinatorBuilder: MockCoordinatorBuilder.mock,
+                completionAction: { continuation.resume(returning: true) },
+                handleError: { error in
+                    authError = error
+                    continuation.resume(returning: false)
+                }
+            )
+            sut.start(url: nil)
+        }
+
+        #expect(authError == .genericError)
+        #expect(!completion)
     }
 
     private func createTokenResponse(_ jsonData: Data) -> TokenResponse {

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/AuthenticationOnboardingCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/AuthenticationOnboardingCoordinatorTests.swift
@@ -74,4 +74,70 @@ class AuthenticationOnboardingCoordinatorTests {
         #expect(completion)
         #expect(mockNavigationController._setViewControllers?.count == .none)
     }
+
+    @Test @MainActor
+    func authenticationError_starts_SignInErrorCoordinator() async throws {
+        let mockAuthenticationService = MockAuthenticationService()
+        let mockAuthenticationOnboardingService = MockAuthenticationOnboardingService()
+        let mockNavigationController = MockNavigationController()
+        let mockCoordinatorBuilder = CoordinatorBuilder.mock
+        mockAuthenticationOnboardingService.isFeatureEnabled = true
+
+        let sut = AuthenticationOnboardingCoordinator(
+            navigationController: mockNavigationController,
+            authenticationService: mockAuthenticationService,
+            authenticationOnboardingService: mockAuthenticationOnboardingService,
+            analyticsService: MockAnalyticsService(),
+            coordinatorBuilder: mockCoordinatorBuilder,
+            completionAction: { }
+        )
+
+        sut.showError(.genericError)
+        #expect(sut.childCoordinators.count == 1)
+    }
+
+    @Test @MainActor
+    func userCancelledError_does_not_start_SignInErrorCoordinator() async throws {
+        let mockAuthenticationService = MockAuthenticationService()
+        let mockAuthenticationOnboardingService = MockAuthenticationOnboardingService()
+        let mockNavigationController = MockNavigationController()
+        let mockCoordinatorBuilder = CoordinatorBuilder.mock
+        mockAuthenticationOnboardingService.isFeatureEnabled = true
+
+        let sut = AuthenticationOnboardingCoordinator(
+            navigationController: mockNavigationController,
+            authenticationService: mockAuthenticationService,
+            authenticationOnboardingService: mockAuthenticationOnboardingService,
+            analyticsService: MockAnalyticsService(),
+            coordinatorBuilder: mockCoordinatorBuilder,
+            completionAction: { }
+        )
+
+        sut.showError(.loginFlow(.userCancelled))
+        #expect(sut.childCoordinators.count == 0)
+    }
+
+    @Test @MainActor
+    func completingSignInError_setsOnboarding() async throws {
+        let mockAuthenticationService = MockAuthenticationService()
+        let mockAuthenticationOnboardingService = MockAuthenticationOnboardingService()
+        let mockNavigationController = MockNavigationController()
+        let mockCoordinatorBuilder = CoordinatorBuilder.mock
+        mockAuthenticationOnboardingService.isFeatureEnabled = true
+
+        let sut = AuthenticationOnboardingCoordinator(
+            navigationController: mockNavigationController,
+            authenticationService: mockAuthenticationService,
+            authenticationOnboardingService: mockAuthenticationOnboardingService,
+            analyticsService: MockAnalyticsService(),
+            coordinatorBuilder: mockCoordinatorBuilder,
+            completionAction: { }
+        )
+
+        sut.showError(.genericError)
+        #expect(sut.childCoordinators.count == 1)
+        mockCoordinatorBuilder._receivedSignInErrorCompletion?()
+        #expect(mockAuthenticationOnboardingService._receivedFetchSlidesCompletion != nil)
+        #expect(mockNavigationController._setViewControllers?.count == .some(1))
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/SignInErrorCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/SignInErrorCoordinatorTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import UIKit
+@testable import govuk_ios
+
+struct SignInErrorCoordinatorTests {
+
+    @Test
+    @MainActor
+    func start_setsSigninErrorView() {
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let navigationController = UINavigationController()
+        let expectedViewController = UIViewController()
+        mockViewControllerBuilder._stubbedSignInErrorViewController = expectedViewController
+
+        let sut = SignInErrorCoordinator(
+            navigationController: navigationController,
+            viewControllerBuilder: mockViewControllerBuilder,
+            analyticsService: MockAnalyticsService(),
+            completion: { })
+
+        sut.start()
+
+        #expect(navigationController.viewControllers.first == expectedViewController)
+    }
+
+    @Test
+    @MainActor
+    func finish_callsCompletion() {
+        let mockBaseCoordinator = MockBaseCoordinator()
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let navigationController = UINavigationController()
+        let expectedViewController = UIViewController()
+        mockViewControllerBuilder._stubbedSignInErrorViewController = expectedViewController
+
+        var didFinish = false
+        let sut = SignInErrorCoordinator(
+            navigationController: navigationController,
+            viewControllerBuilder: mockViewControllerBuilder,
+            analyticsService: MockAnalyticsService(),
+            completion: {
+                didFinish = true
+            }
+        )
+
+        mockBaseCoordinator.start(sut)
+        mockViewControllerBuilder._receivedSignInErrorCompletion?()
+        #expect(didFinish)
+        #expect(mockBaseCoordinator._childDidFinishReceivedChild == sut)
+    }
+
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/SignInErrorViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/SignInErrorViewModelTests.swift
@@ -3,15 +3,14 @@ import Testing
 @testable import govuk_ios
 @testable import GOVKit
 
-struct SignedOutViewModelTests {
+struct SignInErrorViewModelTests {
 
     @Test
-    func signInButton_action_tracksNavigationEvent() {
-        let mockAuthenticationService = MockAuthenticationService()
+    func signInRetryButton_tracksNavigationEvent() {
         let mockAnalyticsService = MockAnalyticsService()
         var didCallCompletion = false
-        let sut = SignedOutViewModel(
-            authenticationService: mockAuthenticationService,
+
+        let sut = SignInErrorViewModel(
             analyticsService: mockAnalyticsService,
             completion: {
                 didCallCompletion = true
@@ -21,6 +20,7 @@ struct SignedOutViewModelTests {
         sut.buttonViewModel.action()
 
         #expect(didCallCompletion)
-        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == String.signOut.localized("signedOutButtonTitle"))
+        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == String.signOut.localized("signInRetryButtonTitle"))
     }
+
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/SignedOutViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/SignedOutViewModelTests.swift
@@ -18,7 +18,7 @@ struct SignedOutViewModelTests {
             }
         )
 
-        sut.signedOutButtonViewModel.action()
+        sut.buttonViewModel.action()
 
         #expect(didCallCompletion)
         #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == String.signOut.localized("signedOutButtonTitle"))


### PR DESCRIPTION
Refactored sign out view to be more generic so it could also be used for sign in error view.
Sign in errors are now propagated up to AuthenticationOnboardingCoordinator for handling of display
NOTE:  the showError() method is internal (not private) as this was the only way I could see it be made testable without considerable refactoring.