### PR TITLE
Edit local authority VO fixes

### DIFF
--- a/Production/govuk_ios/Resources/Strings/LocalAuthority.xcstrings
+++ b/Production/govuk_ios/Resources/Strings/LocalAuthority.xcstrings
@@ -23,6 +23,17 @@
         }
       }
     },
+    "localAuthorityEditButtonAltText" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit your local council"
+          }
+        }
+      }
+    },
     "localAuthorityEmptyTextField" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Production/govuk_ios/ViewModels/StoredLocalAuthorityWidgetViewModel.swift
+++ b/Production/govuk_ios/ViewModels/StoredLocalAuthorityWidgetViewModel.swift
@@ -29,6 +29,10 @@ class StoredLocalAuthorityWidgetViewModel {
         "localAuthorityTwoTierChildDescription"
     )
 
+    let editButtonAltText = String.localAuthority.localized(
+        "localAuthorityEditButtonAltText"
+    )
+
     private func returnCardDescription(authority: LocalAuthorityItem) -> String {
         if authority.parent != nil {
             return localAuthorityTwoTierChildDescription(

--- a/Production/govuk_ios/Views/Home/LocalAuthority/StoredLocalAuthorityCardView.swift
+++ b/Production/govuk_ios/Views/Home/LocalAuthority/StoredLocalAuthorityCardView.swift
@@ -15,6 +15,10 @@ struct StoredLocalAuthorityCardView: View {
                     Image(systemName: "arrow.up.right")
                         .foregroundColor(Color(UIColor.govUK.text.link))
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(model.name)
+                .accessibilityAddTraits(.isLink)
+                .accessibilityHint(String.common.localized("openWebLinkHint"))
                 .padding(.bottom, 4)
                 HStack {
                     Text(model.description)
@@ -24,8 +28,6 @@ struct StoredLocalAuthorityCardView: View {
                     Spacer()
                 }
             }
-            .accessibilityAddTraits(.isLink)
-            .accessibilityHint(String.common.localized("openWebLinkHint"))
             .padding()
             .overlay(RoundedRectangle(cornerRadius: 10)
                 .stroke(

--- a/Production/govuk_ios/Views/Home/LocalAuthority/StoredLocalAuthorityWidgetView.swift
+++ b/Production/govuk_ios/Views/Home/LocalAuthority/StoredLocalAuthorityWidgetView.swift
@@ -23,6 +23,7 @@ struct StoredLocalAuthorityWidgetView: View {
                             .font(.govUK.body)
                             .foregroundColor(Color(uiColor: UIColor.govUK.text.buttonSecondary))
                     }
+                    .accessibilityLabel(viewModel.editButtonAltText)
                 }
                 if viewModel.localAuthorities.count == 2 {
                     HStack {


### PR DESCRIPTION
VO fixes:  

- Add alt text for local authority edit button.
- Reconfigure accessibility elements on local council card to only read out link info once.