### PR TITLE
Local authority error handling

### DIFF
--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -256,6 +256,8 @@
 		D056CE762D3A848A005845E0 /* InformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D056CE752D3A847F005845E0 /* InformationView.swift */; };
 		D05AF4DA2CAD3C2900F86DD0 /* TopicDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05AF4D92CAD3C2900F86DD0 /* TopicDetailView.swift */; };
 		D05AF4DC2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05AF4DB2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift */; };
+		D06C2A4F2DDF2FCF0045C674 /* ResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06C2A4E2DDF2FCF0045C674 /* ResponseHandler.swift */; };
+		D06C2A512DDF39C90045C674 /* LocalAuthorityResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06C2A502DDF39C90045C674 /* LocalAuthorityResponseHandler.swift */; };
 		D06EB96C2CA6F71E007EA081 /* TopicCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06EB96B2CA6F71E007EA081 /* TopicCard.swift */; };
 		D076F9192D3544F0000278D5 /* SearchHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D076F9182D3544F0000278D5 /* SearchHistoryCell.swift */; };
 		D07E7A582DAE662A00B92D40 /* LocalAuthorityRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07E7A572DAE662A00B92D40 /* LocalAuthorityRepository.swift */; };
@@ -607,6 +609,8 @@
 		D056CE752D3A847F005845E0 /* InformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationView.swift; sourceTree = "<group>"; };
 		D05AF4D92CAD3C2900F86DD0 /* TopicDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicDetailView.swift; sourceTree = "<group>"; };
 		D05AF4DB2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsWidgetViewModel.swift; sourceTree = "<group>"; };
+		D06C2A4E2DDF2FCF0045C674 /* ResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseHandler.swift; sourceTree = "<group>"; };
+		D06C2A502DDF39C90045C674 /* LocalAuthorityResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthorityResponseHandler.swift; sourceTree = "<group>"; };
 		D06EB96B2CA6F71E007EA081 /* TopicCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicCard.swift; sourceTree = "<group>"; };
 		D076F9182D3544F0000278D5 /* SearchHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryCell.swift; sourceTree = "<group>"; };
 		D07E7A572DAE662A00B92D40 /* LocalAuthorityRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthorityRepository.swift; sourceTree = "<group>"; };
@@ -892,6 +896,7 @@
 				5D0BD4582C9B1BBA00220625 /* SearchServiceClient.swift */,
 				D04191852CA6A5910034722A /* TopicsServiceClient.swift */,
 				4EBCA3282DAC546A0063A723 /* LocalAuthorityServiceClient.swift */,
+				D06C2A502DDF39C90045C674 /* LocalAuthorityResponseHandler.swift */,
 			);
 			path = ServiceClients;
 			sourceTree = "<group>";
@@ -1118,6 +1123,7 @@
 				5D15A8E72C6A47770050C780 /* GOVRequest.swift */,
 				5D349F662C6B548200B7F747 /* RequestBuilder.swift */,
 				D0E855D32DDB85C1003B4D7A /* URLEncodedRequestBuilder.swift */,
+				D06C2A4E2DDF2FCF0045C674 /* ResponseHandler.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -2075,6 +2081,7 @@
 				16E8644C2D28362000BCC0FC /* SearchSuggestions.swift in Sources */,
 				1679D5752C3F5E6900AA2EB0 /* SettingsCoordinator.swift in Sources */,
 				5D15A8E82C6A47770050C780 /* GOVRequest.swift in Sources */,
+				D06C2A4F2DDF2FCF0045C674 /* ResponseHandler.swift in Sources */,
 				D08A9A802DB9286D002E9C78 /* SignOutConfirmationCoordinator.swift in Sources */,
 				5D0F199E2D5F7DB70011976C /* OnboardingSlideAnimationViewModel.swift in Sources */,
 				4EBE646B2D15AAD6007A6E97 /* MinimumLengthValidator.swift in Sources */,
@@ -2090,6 +2097,7 @@
 				4E6663CA2C737EF50063E81C /* Config.swift in Sources */,
 				3D3378142CAAC0E0004BF83F /* AppUnavailableContainerView.swift in Sources */,
 				166248242C4AC91E009F7E58 /* HomeCoordinator.swift in Sources */,
+				D06C2A512DDF39C90045C674 /* LocalAuthorityResponseHandler.swift in Sources */,
 				4EFE22A12D0CD08900136D56 /* Redactor.swift in Sources */,
 				D056CE742D3A83F2005845E0 /* UserFeedbackViewModel.swift in Sources */,
 				16EE1A412C6F8968005E820F /* SearchViewController.swift in Sources */,

--- a/Production/govuk_ios/Extensions/Container/Container+APIClients.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+APIClients.swift
@@ -53,7 +53,8 @@ extension Container {
             APIServiceClient(
                 baseUrl: Constants.API.defaultLocalAuthorityURL,
                 session: self.urlSession(),
-                requestBuilder: RequestBuilder()
+                requestBuilder: RequestBuilder(),
+                responseHandler: LocalAuthorityResponseHandler()
             )
         }
     }

--- a/Production/govuk_ios/Model/LocalAuthority/LocalAuthorityResponse.swift
+++ b/Production/govuk_ios/Model/LocalAuthority/LocalAuthorityResponse.swift
@@ -3,36 +3,32 @@ import Foundation
 enum LocalAuthorityResponseType {
     case authority(Authority)
     case addresses([LocalAuthorityAddress])
-    case errorMessage(String?)
+    case unknown
 }
 
 struct LocalAuthorityResponse: Codable {
     let localAuthority: Authority?
     let localAuthorityAddresses: [LocalAuthorityAddress]?
-    let localAuthorityErrorMessage: String?
 
     init(localAuthority: Authority? = nil,
-         localAuthorityAddresses: [LocalAuthorityAddress]? = nil,
-         localAuthorityErrorMessage: String? = nil) {
+         localAuthorityAddresses: [LocalAuthorityAddress]? = nil) {
         self.localAuthority = localAuthority
         self.localAuthorityAddresses = localAuthorityAddresses
-        self.localAuthorityErrorMessage = localAuthorityErrorMessage
     }
 
     enum CodingKeys: String, CodingKey {
         case localAuthority = "local_authority"
         case localAuthorityAddresses = "addresses"
-        case localAuthorityErrorMessage = "message"
     }
 
     var type: LocalAuthorityResponseType {
-        switch(localAuthority, localAuthorityAddresses, localAuthorityErrorMessage) {
-        case (.some, nil, nil):
+        switch(localAuthority, localAuthorityAddresses) {
+        case (.some, nil):
             return .authority(localAuthority!)
-        case (nil, .some, nil):
+        case (nil, .some):
             return .addresses(localAuthorityAddresses!)
         default:
-            return .errorMessage(localAuthorityErrorMessage)
+            return .unknown
         }
     }
 }

--- a/Production/govuk_ios/Networking/APIServiceClient.swift
+++ b/Production/govuk_ios/Networking/APIServiceClient.swift
@@ -19,13 +19,16 @@ struct APIServiceClient: APIServiceClientInterface {
     private let baseUrl: URL
     private let session: URLSession
     private let requestBuilder: RequestBuilderInterface
+    private let responseHandler: ResponseHandler?
 
     init(baseUrl: URL,
          session: URLSession,
-         requestBuilder: RequestBuilderInterface) {
+         requestBuilder: RequestBuilderInterface,
+         responseHandler: ResponseHandler? = nil) {
         self.baseUrl = baseUrl
         self.session = session
         self.requestBuilder = requestBuilder
+        self.responseHandler = responseHandler
     }
 }
 
@@ -49,8 +52,10 @@ extension APIServiceClient {
         let task = session.dataTask(
             with: request,
             completionHandler: { data, response, error in
+                let localError = responseHandler?.handleResponse(response,
+                                                                 error: error) ?? error
                 let result: NetworkResult<Data>
-                switch (data, error) {
+                switch (data, localError) {
                 case (_, .some(let error)):
                     result = .failure(error)
                 case (.some(let data), _):

--- a/Production/govuk_ios/Networking/ResponseHandler.swift
+++ b/Production/govuk_ios/Networking/ResponseHandler.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+protocol ResponseHandler {
+    func handleResponse(_ response: URLResponse?,
+                        error: Error?) -> Error?
+}
+
+enum HTTPError: Error {
+    case badRequest
+    case unauthorized
+    case notFound
+    case unknown
+}

--- a/Production/govuk_ios/ServiceClients/LocalAuthorityResponseHandler.swift
+++ b/Production/govuk_ios/ServiceClients/LocalAuthorityResponseHandler.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct LocalAuthorityResponseHandler: ResponseHandler {
+    func handleResponse(_ response: URLResponse?,
+                        error: Error?) -> Error? {
+        guard error == nil else {
+            return error
+        }
+        guard let httpURLResponse = response as? HTTPURLResponse else {
+            return nil
+        }
+
+        let statusCode = httpURLResponse.statusCode
+        if (200..<300).contains(statusCode) {
+            return nil
+        }
+
+        switch statusCode {
+        case 400:
+            return LocalAuthorityError.invalidPostcode
+        case 404:
+            return LocalAuthorityError.unknownPostcode
+        default:
+            return LocalAuthorityError.apiUnavailable
+        }
+    }
+}

--- a/Production/govuk_ios/ServiceClients/LocalAuthorityServiceClient.swift
+++ b/Production/govuk_ios/ServiceClients/LocalAuthorityServiceClient.swift
@@ -20,6 +20,8 @@ enum LocalAuthorityError: LocalizedError {
     case networkUnavailable
     case apiUnavailable
     case decodingError
+    case unknownPostcode
+    case invalidPostcode
 }
 
 struct LocalAuthorityServiceClient: LocalAuthorityServiceClientInterface {
@@ -80,7 +82,7 @@ struct LocalAuthorityServiceClient: LocalAuthorityServiceClientInterface {
                 if nsError.code == NSURLErrorNotConnectedToInternet {
                     return LocalAuthorityError.networkUnavailable
                 } else {
-                    return LocalAuthorityError.apiUnavailable
+                    return (error as? LocalAuthorityError) ?? LocalAuthorityError.apiUnavailable
                 }
             }.flatMap {
                 do {

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Networking/APIServiceClientTests+LocalAuthority.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Networking/APIServiceClientTests+LocalAuthority.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+import GOVKit
+@testable import govuk_ios
+
+@Suite(.serialized)
+struct APIServiceClientTests_LocalAuthority {
+    @Test
+    func send_successResponse_returnsExpectedResult() async {
+        let subject = APIServiceClient(
+            baseUrl: URL(string: "https://www.google.com")!,
+            session: URLSession.mock,
+            requestBuilder: RequestBuilder(),
+            responseHandler: LocalAuthorityResponseHandler()
+
+        )
+        let request = GOVRequest.localAuthority(postcode: "E18QS")
+        let expectedResponse = HTTPURLResponse.arrange(statusCode: 200)
+        let expectedData = Data()
+        MockURLProtocol.requestHandlers[
+            "https://www.google.com/find-local-council/query.json"
+        ] = { request in
+            return (expectedResponse, expectedData, nil)
+        }
+
+        let resultData = await withCheckedContinuation { continuation in
+            subject.send(
+                request: request,
+                completion: { result in
+                    let resultData = try? result.get()
+                    continuation.resume(returning: resultData)
+                }
+            )
+        }
+        #expect(resultData == expectedData)
+    }
+
+    @Test(arguments: zip(
+        [400,
+         404,
+         500],
+        [LocalAuthorityError.invalidPostcode,
+         .unknownPostcode,
+         .apiUnavailable]
+    ))
+    func send_httpResponseError_returnsExpectedResult(
+        statusCode: Int,
+        authorityError: LocalAuthorityError
+    ) async throws{
+        let subject = APIServiceClient(
+            baseUrl: URL(string: "https://www.google.com")!,
+            session: URLSession.mock,
+            requestBuilder: RequestBuilder(),
+            responseHandler: LocalAuthorityResponseHandler()
+        )
+        let request = GOVRequest.localAuthority(postcode: "E18QS")
+        let expectedResponse = HTTPURLResponse.arrange(statusCode: statusCode)
+        MockURLProtocol.requestHandlers[
+            "https://www.google.com/find-local-council/query.json"
+        ] = { request in
+            return (expectedResponse, nil, nil)
+        }
+
+        let result = await withCheckedContinuation { continuation in
+            subject.send(
+                request: request,
+                completion: { continuation.resume(returning: $0) }
+            )
+        }
+        let error = try #require(result.getError() as? LocalAuthorityError)
+        #expect(error == authorityError)
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Networking/APIServiceClientTests+LocalAuthority.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Networking/APIServiceClientTests+LocalAuthority.swift
@@ -18,7 +18,7 @@ struct APIServiceClientTests_LocalAuthority {
         let expectedResponse = HTTPURLResponse.arrange(statusCode: 200)
         let expectedData = Data()
         MockURLProtocol.requestHandlers[
-            "https://www.google.com/find-local-council/query.json"
+            "https://www.google.com/api/local-authority"
         ] = { request in
             return (expectedResponse, expectedData, nil)
         }
@@ -56,7 +56,7 @@ struct APIServiceClientTests_LocalAuthority {
         let request = GOVRequest.localAuthority(postcode: "E18QS")
         let expectedResponse = HTTPURLResponse.arrange(statusCode: statusCode)
         MockURLProtocol.requestHandlers[
-            "https://www.google.com/find-local-council/query.json"
+            "https://www.google.com/api/local-authority"
         ] = { request in
             return (expectedResponse, nil, nil)
         }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ServiceClients/LocalAuthorityServiceClientTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ServiceClients/LocalAuthorityServiceClientTests.swift
@@ -176,23 +176,6 @@ struct LocalAuthorityServiceClientTests {
         #expect(localResult == nil)
         #expect(result.getError() == .decodingError)
     }
-
-    @Test
-    func fetchLocalAuthority_localErrorMessage_returnsExpectedresult() async throws {
-        let mockAPI = MockAPIServiceClient()
-        let sut = LocalAuthorityServiceClient(serviceClient: mockAPI)
-        mockAPI._stubbedSendResponse = .success(Self.localAuthorityErrorMessage)
-
-        let result = await withCheckedContinuation { continuation in
-            sut.fetchLocalAuthority(
-                postcode: "test") { result in
-                    continuation.resume(returning: result)
-                }
-        }
-        let localResult = try? result.get()
-        let errormessage = localResult?.localAuthorityErrorMessage
-        #expect(errormessage == "Postcode not found")
-    }
 }
 private extension LocalAuthorityServiceClientTests {
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/LocalAuthortiyServiceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/LocalAuthortiyServiceTests.swift
@@ -284,27 +284,4 @@ struct LocalAuthorityServiceTests {
         #expect(result.getError() == .networkUnavailable)
         #expect(!mockRepository._didSaveLocalAuthority)
     }
-
-    @Test
-    func fetchLocalAuthority_localErrorMessage_returnsExpectedResult() async throws {
-        let mockServiceClient = MockLocalServiceClient()
-        let response = LocalAuthorityResponse(localAuthorityErrorMessage: "errorMessage")
-        mockServiceClient._stubbedLocalPostcodeResult = .success(response)
-
-        let mockRepository = MockLocalAuthorityRepository()
-        let sut = LocalAuthorityService(
-            serviceClient: mockServiceClient,
-            repository: mockRepository
-        )
-        let result = await withCheckedContinuation { continuation in
-            sut.fetchLocalAuthority(
-                postcode: "test") { result in
-                    continuation.resume(returning: result)
-                }
-        }
-        let localResult = try? result.get()
-        let errorMessage = localResult?.localAuthorityErrorMessage
-        #expect(errorMessage == "errorMessage")
-        #expect(!mockRepository._didSaveLocalAuthority)
-    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/LocalAuthority/LocalAuthorityPostcodeEntryViewmodelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/LocalAuthority/LocalAuthorityPostcodeEntryViewmodelTests.swift
@@ -74,12 +74,8 @@ struct LocalAuthorityPostcodeEntryViewmodelTests {
 
     @Test
     func returnErrorMessage_invalidPostcode_returnsExpectedResult() async throws {
-        var cancellables = Set<AnyCancellable>()
-        let expectedResult = LocalAuthorityResponse(
-            localAuthorityErrorMessage: "Invalid postcode"
-        )
         let mockService = MockLocalAuthorityService()
-        mockService._stubbedFetchLocalPostcodeResult = .success(expectedResult)
+        mockService._stubbedFetchLocalPostcodeResult = .failure(.invalidPostcode)
 
         let sut = LocalAuthorityPostcodeEntryViewModel(
             service: mockService,
@@ -87,29 +83,17 @@ struct LocalAuthorityPostcodeEntryViewmodelTests {
             resolveAmbiguityAction: { _, _ in },
             dismissAction: {}
         )
-        let result = await withCheckedContinuation { continuation in
-            sut.$error
-                .dropFirst()
-                .receive(on: DispatchQueue.main)
-                .sink { errorMessage in
-                    continuation.resume(returning: errorMessage)
-                }
-                .store(in: &cancellables)
-            sut.postCode = "test"
-            sut.primaryButtonViewModel.action()
-        }
-        #expect(result?.errorMessage == "Enter a postcode in the correct format")
+
+        sut.postCode = "test"
+        sut.primaryButtonViewModel.action()
+        #expect(sut.error?.errorMessage == "Enter a postcode in the correct format")
     }
 
 
     @Test
     func returnErrorMessage_postcodeNotFound_returnsExpectedResult() async throws {
-        var cancellables = Set<AnyCancellable>()
-        let expectedResult = LocalAuthorityResponse(
-            localAuthorityErrorMessage: "Postcode not found"
-        )
         let mockService = MockLocalAuthorityService()
-        mockService._stubbedFetchLocalPostcodeResult = .success(expectedResult)
+        mockService._stubbedFetchLocalPostcodeResult = .failure(.unknownPostcode)
 
         let sut = LocalAuthorityPostcodeEntryViewModel(
             service: mockService,
@@ -117,18 +101,9 @@ struct LocalAuthorityPostcodeEntryViewmodelTests {
             resolveAmbiguityAction: { _, _ in },
             dismissAction: {}
         )
-        let result = await withCheckedContinuation { continuation in
-            sut.$error
-                .dropFirst()
-                .receive(on: DispatchQueue.main)
-                .sink { errorMessage in
-                    continuation.resume(returning: errorMessage)
-                }
-                .store(in: &cancellables)
-            sut.postCode = "test"
-            sut.primaryButtonViewModel.action()
-        }
-        #expect(result?.errorMessage == "We could not find a council for this postcode. Check the postcode and try again.")
+        sut.postCode = "test"
+        sut.primaryButtonViewModel.action()
+        #expect(sut.error?.errorMessage == "We could not find a council for this postcode. Check the postcode and try again.")
     }
 
     @Test


### PR DESCRIPTION
Refactor of how we handle errors so that we can examine HTTPResponse status codes if needed.
The APIServiceClient now accepts an optional ResponseHandler on initialization.
If this handler is present, it intercepts the URLResponse and possible error for processing (i.e., examine the response status), then returns an optional error.
For LocalAuthority, this means we no longer look for an error message in response data.
