### PR TITLE
Add "scope" to token parameters that are sent during login

### DIFF
--- a/Production/govuk_ios/ServiceClients/AuthenticationServiceClient.swift
+++ b/Production/govuk_ios/ServiceClients/AuthenticationServiceClient.swift
@@ -109,6 +109,7 @@ class AuthenticationServiceClient: AuthenticationServiceClientInterface {
             prefersEphemeralWebSession: true,
             redirectURI: Constants.API.authenticationCallbackUri,
             locale: .en,
+            tokenParameters: ["scope": "openid email"],
             tokenHeaders: ["x-attestation-token": token]
         )
     }


### PR DESCRIPTION
"Scope" is now required in the token request that is performed during the login flow.  This needed to be added as part of LoginSessionConfiguration.