### PR TITLE
govukapp-1932 persist conversation

### DIFF
--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -302,6 +302,8 @@
 		D093BA632CB0499A004F489B /* EditTopicsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093BA622CB0499A004F489B /* EditTopicsView.swift */; };
 		D093BA652CB04C68004F489B /* EditTopicsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093BA642CB04C68004F489B /* EditTopicsViewModel.swift */; };
 		D093BA672CB3CBEC004F489B /* EditTopicsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093BA662CB3CBEC004F489B /* EditTopicsCoordinator.swift */; };
+		D096BFEE2E03F60F00426C51 /* ChatRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D096BFED2E03F60F00426C51 /* ChatRepository.swift */; };
+		D096BFF22E04124E00426C51 /* ChatItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D096BFF12E04124E00426C51 /* ChatItem.swift */; };
 		D0A8B3C22C9DC66E00849304 /* integration_pubkey.der in Resources */ = {isa = PBXBuildFile; fileRef = D0A8B3C12C9DC66E00849304 /* integration_pubkey.der */; };
 		D0A8B3C42C9DD01200849304 /* Codable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A8B3C32C9DD01200849304 /* Codable+Extensions.swift */; };
 		D0C1F1E42CA440F200DD3D61 /* TopicCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C1F1E32CA440F200DD3D61 /* TopicCardModel.swift */; };
@@ -679,6 +681,8 @@
 		D093BA622CB0499A004F489B /* EditTopicsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsView.swift; sourceTree = "<group>"; };
 		D093BA642CB04C68004F489B /* EditTopicsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsViewModel.swift; sourceTree = "<group>"; };
 		D093BA662CB3CBEC004F489B /* EditTopicsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTopicsCoordinator.swift; sourceTree = "<group>"; };
+		D096BFED2E03F60F00426C51 /* ChatRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRepository.swift; sourceTree = "<group>"; };
+		D096BFF12E04124E00426C51 /* ChatItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatItem.swift; sourceTree = "<group>"; };
 		D0A8B3C12C9DC66E00849304 /* integration_pubkey.der */ = {isa = PBXFileReference; lastKnownFileType = file; path = integration_pubkey.der; sourceTree = "<group>"; };
 		D0A8B3C32C9DD01200849304 /* Codable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Codable+Extensions.swift"; sourceTree = "<group>"; };
 		D0B3EBFD2CE226AC00A8F321 /* GoogleService-Info-Dev.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Dev.plist"; sourceTree = "<group>"; };
@@ -1228,6 +1232,7 @@
 		5D41DB6A2C088CA30011E691 /* Repositories */ = {
 			isa = PBXGroup;
 			children = (
+				D096BFED2E03F60F00426C51 /* ChatRepository.swift */,
 				5DD4CB112D9548DF00459FB5 /* ActivityRepository.swift */,
 				D0EB02802D37F02400B310D8 /* CoreDataRepository.swift */,
 				D0EB04812D37F34200B310D8 /* GOV.xcdatamodeld */,
@@ -1701,6 +1706,7 @@
 				D04DD3292E0046DC002B5F19 /* AnsweredQuestion.swift */,
 				D04DD32A2E0046DC002B5F19 /* History.swift */,
 				D04DD32B2E0046DC002B5F19 /* PendingQuestion.swift */,
+				D096BFF12E04124E00426C51 /* ChatItem.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -2154,6 +2160,7 @@
 				5D62ABC32C32F49F0072BE6C /* Container+Configs.swift in Sources */,
 				D05AF4DA2CAD3C2900F86DD0 /* TopicDetailView.swift in Sources */,
 				5DE970572C297CFE009D66C4 /* AppEvent+Convenience.swift in Sources */,
+				D096BFEE2E03F60F00426C51 /* ChatRepository.swift in Sources */,
 				1650769D2D3DAC0D0034C4F1 /* SearchSuggestion.swift in Sources */,
 				5D02783C2C29D9BB00F2A4EB /* LaunchViewModel.swift in Sources */,
 				5DC069ED2C3BFD6400A81AAE /* AccessibilityManager.swift in Sources */,
@@ -2379,6 +2386,7 @@
 				5DA6E5332C47BD2700D41263 /* DeeplinkRouteProvider.swift in Sources */,
 				5DFDEBF12CEE396D00F7A365 /* UserProperty+Convenience.swift in Sources */,
 				4E265D2A2DB0E6510089CF9E /* Authority.swift in Sources */,
+				D096BFF22E04124E00426C51 /* ChatItem.swift in Sources */,
 				4E265D2D2DB0E6510089CF9E /* LocalAuthorityAddress.swift in Sources */,
 				5D54F4752CC84A5B00A3B6A7 /* TopicDetailsCoordinator.swift in Sources */,
 				5DAD717A2BD250DB0075F648 /* SceneDelegate.swift in Sources */,

--- a/Production/govuk_ios/Extensions/Container/Container+Repositories.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+Repositories.swift
@@ -28,4 +28,10 @@ extension Container {
             SearchHistoryRepository(coreData: self.coreDataRepository())
         }
     }
+
+    var chatRepository: Factory<ChatRepositoryInterface> {
+        Factory(self) {
+            ChatRepository(coreData: self.coreDataRepository())
+        }
+    }
 }

--- a/Production/govuk_ios/Extensions/Container/Container+Services.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+Services.swift
@@ -206,7 +206,8 @@ extension Container {
     var chatService: Factory<ChatServiceInterface> {
         Factory(self) {
             ChatService(
-                serviceClient: self.chatServiceClient.resolve()
+                serviceClient: self.chatServiceClient.resolve(),
+                chatRepository: self.chatRepository.resolve()
             )
         }
     }

--- a/Production/govuk_ios/Model/Chat/ChatItem.swift
+++ b/Production/govuk_ios/Model/Chat/ChatItem.swift
@@ -1,0 +1,11 @@
+import Foundation
+import CoreData
+
+@objc(ChatItem)
+class ChatItem: NSManagedObject {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ChatItem> {
+        NSFetchRequest<ChatItem>(entityName: "ChatItem")
+    }
+
+    @NSManaged public var conversationId: String?
+}

--- a/Production/govuk_ios/Repositories/ChatRepository.swift
+++ b/Production/govuk_ios/Repositories/ChatRepository.swift
@@ -1,0 +1,36 @@
+import Foundation
+import CoreData
+import GOVKit
+
+protocol ChatRepositoryInterface {
+    func saveConversation(_ conversationId: String?)
+    func fetchConversation() -> String?
+}
+
+struct ChatRepository: ChatRepositoryInterface {
+    private let coreData: CoreDataRepositoryInterface
+
+    init(coreData: CoreDataRepositoryInterface) {
+        self.coreData = coreData
+    }
+
+    func saveConversation(_ conversationId: String?) {
+        let context = coreData.backgroundContext
+        let request = ChatItem.fetchRequest()
+        context.performAndWait {
+            let chatItem = try? context.fetch(request).first ?? ChatItem(context: context)
+            chatItem?.conversationId = conversationId
+            try? context.save()
+        }
+    }
+
+    func fetchConversation() -> String? {
+        let context = coreData.backgroundContext
+        return context.performAndWait {
+            if let chatItem = try? context.fetch(ChatItem.fetchRequest()).first {
+                return chatItem.conversationId
+            }
+            return nil
+        }
+    }
+}

--- a/Production/govuk_ios/Repositories/GOV.xcdatamodeld/GOV_v2.xcdatamodel/contents
+++ b/Production/govuk_ios/Repositories/GOV.xcdatamodeld/GOV_v2.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24E248" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ActivityItem" representedClassName="ActivityItem" syncable="YES">
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" attributeType="String"/>
@@ -11,12 +11,16 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
+    <entity name="ChatItem" representedClassName="ChatItem" syncable="YES">
+        <attribute name="conversationId" optional="YES" attributeType="String"/>
+    </entity>
     <entity name="LocalAuthorityItem" representedClassName="LocalAuthorityItem" syncable="YES">
         <attribute name="homepageUrl" attributeType="String"/>
         <attribute name="name" attributeType="String"/>
         <attribute name="slug" attributeType="String"/>
         <attribute name="tier" attributeType="String"/>
-        <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LocalAuthorityItem"/>
+        <relationship name="child" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LocalAuthorityItem" inverseName="parent" inverseEntity="LocalAuthorityItem"/>
+        <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LocalAuthorityItem" inverseName="child" inverseEntity="LocalAuthorityItem"/>
     </entity>
     <entity name="SearchHistoryItem" representedClassName="SearchHistoryItem" syncable="YES">
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Repositories/MockChatRespository.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Repositories/MockChatRespository.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+@testable import govuk_ios
+
+final class MockChatRespository: ChatRepositoryInterface {
+    var _didSaveConversation = false
+    var _conversationId: String?
+    func saveConversation(_ conversationId: String?) {
+        _didSaveConversation = true
+        _conversationId = conversationId
+    }
+
+    func fetchConversation() -> String? {
+        _conversationId
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Repositories/ChatRespositoryTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Repositories/ChatRespositoryTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+import CoreData
+
+@testable import govuk_ios
+
+struct ChatRespositoryTests {
+
+    @Test
+    func save_chatItem_savesConversationId() throws {
+        let coreData = CoreDataRepository.arrangeAndLoad
+        let sut = ChatRepository(coreData: coreData)
+        let expectedConversationId = "conversation_id"
+
+        sut.saveConversation(expectedConversationId)
+
+        var results: [ChatItem] = []
+        coreData.backgroundContext.performAndWait {
+            let fetchRequest = ChatItem.fetchRequest()
+            results = (try? coreData.backgroundContext.fetch(fetchRequest)) ?? []
+        }
+
+        #expect(results.count == 1)
+        #expect(results.first?.conversationId == expectedConversationId)
+    }
+
+    @Test
+    func save_chatItem_savesOnlyOneConversationId() throws {
+        let coreData = CoreDataRepository.arrangeAndLoad
+        let sut = ChatRepository(coreData: coreData)
+        let expectedConversationId = "conversation_id"
+        let secondExpectedConversationId = "second_conversation_id"
+
+        sut.saveConversation(expectedConversationId)
+        sut.saveConversation(secondExpectedConversationId)
+
+        var results: [ChatItem] = []
+        coreData.backgroundContext.performAndWait {
+            let fetchRequest = ChatItem.fetchRequest()
+            results = (try? coreData.backgroundContext.fetch(fetchRequest)) ?? []
+        }
+
+        #expect(results.count == 1)
+        #expect(results.first?.conversationId == secondExpectedConversationId)
+    }
+
+    @Test
+    func save_chatItem_savesNilConversationId() throws {
+        let coreData = CoreDataRepository.arrangeAndLoad
+        let sut = ChatRepository(coreData: coreData)
+
+        sut.saveConversation(nil)
+
+        var results: [ChatItem] = []
+        coreData.backgroundContext.performAndWait {
+            let fetchRequest = ChatItem.fetchRequest()
+            results = (try? coreData.backgroundContext.fetch(fetchRequest)) ?? []
+        }
+
+        #expect(results.count == 1)
+        #expect(results.first?.conversationId == nil)
+    }
+
+    @Test
+    func fetchConversation_fetchesExpectedItem() {
+        let coreData = CoreDataRepository.arrangeAndLoad
+        let sut = ChatRepository(coreData: coreData)
+        let expectedConversationId = "conversation_id"
+
+        let context = coreData.backgroundContext
+        let chatItem = ChatItem(context: context)
+        chatItem.conversationId = expectedConversationId
+        context.performAndWait {
+            try? context.save()
+        }
+
+        let conversationId = sut.fetchConversation()
+        #expect(conversationId == expectedConversationId)
+    }
+}


### PR DESCRIPTION
Create chat repository (core data) for storing conversationId.  Using core data for security as well as anticipation of storing multiple chats per user.
Update chat Service to store/fetch conversationId and fetch chat history.