### PR TITLE
govukapp 1561 jailbreak detection

### DIFF
--- a/GOVKit/Sources/GOVKit/Extensions/UIKit/URLOpener.swift
+++ b/GOVKit/Sources/GOVKit/Extensions/UIKit/URLOpener.swift
@@ -6,6 +6,9 @@ public protocol URLOpener {
 
     @discardableResult
     func openIfPossible(_ urlString: String) -> Bool
+
+    @discardableResult
+    func canOpenURL(_ url: URL) -> Bool
 }
 
 extension URLOpener {

--- a/GOVKit/Tests/GOVKitTests/Specs/Extensions/UIKit/URLOpenerTests.swift
+++ b/GOVKit/Tests/GOVKitTests/Specs/Extensions/UIKit/URLOpenerTests.swift
@@ -29,4 +29,7 @@ struct TestURLOpener: URLOpener {
     func openIfPossible(_ url: URL) -> Bool {
         true
     }
+    func canOpenURL(_ url: URL) -> Bool {
+        true
+    }
 }

--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		D05AF4DC2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05AF4DB2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift */; };
 		D06C2A4F2DDF2FCF0045C674 /* ResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06C2A4E2DDF2FCF0045C674 /* ResponseHandler.swift */; };
 		D06C2A512DDF39C90045C674 /* LocalAuthorityResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06C2A502DDF39C90045C674 /* LocalAuthorityResponseHandler.swift */; };
+		D06C49B62DE5D2510045C674 /* JailbreakDetectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06C49B52DE5D2510045C674 /* JailbreakDetectionService.swift */; };
 		D06C56092DE70F4D0045C674 /* AppAttestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06C56082DE70F4D0045C674 /* AppAttestService.swift */; };
 		D06C560B2DE711340045C674 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = D06C560A2DE711340045C674 /* FirebaseAppCheck */; };
 		D06EB96C2CA6F71E007EA081 /* TopicCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06EB96B2CA6F71E007EA081 /* TopicCard.swift */; };
@@ -308,6 +309,7 @@
 		D0A8B3C42C9DD01200849304 /* Codable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A8B3C32C9DD01200849304 /* Codable+Extensions.swift */; };
 		D0C1F1E42CA440F200DD3D61 /* TopicCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C1F1E32CA440F200DD3D61 /* TopicCardModel.swift */; };
 		D0C1F1E62CA4434100DD3D61 /* TopicsWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C1F1E52CA4432F00DD3D61 /* TopicsWidgetView.swift */; };
+		D0D2C6932E13F87300620DC2 /* DynamicLibraryWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D2C6922E13F85B00620DC2 /* DynamicLibraryWrapper.swift */; };
 		D0D655E82D26A79000571841 /* UIApplication+URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D655E72D26A79000571841 /* UIApplication+URLOpener.swift */; };
 		D0D661A32D285D1B00571841 /* GOVKitTestUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = D0D661A22D285D1B00571841 /* GOVKitTestUtilities */; };
 		D0D9B0942D2C240E0051EDDD /* GOVKitTestUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = D0D9B0932D2C240E0051EDDD /* GOVKitTestUtilities */; };
@@ -663,6 +665,7 @@
 		D05AF4DB2CAD3C4E00F86DD0 /* TopicsWidgetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsWidgetViewModel.swift; sourceTree = "<group>"; };
 		D06C2A4E2DDF2FCF0045C674 /* ResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseHandler.swift; sourceTree = "<group>"; };
 		D06C2A502DDF39C90045C674 /* LocalAuthorityResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthorityResponseHandler.swift; sourceTree = "<group>"; };
+		D06C49B52DE5D2510045C674 /* JailbreakDetectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JailbreakDetectionService.swift; sourceTree = "<group>"; };
 		D06C56082DE70F4D0045C674 /* AppAttestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAttestService.swift; sourceTree = "<group>"; };
 		D06EB96B2CA6F71E007EA081 /* TopicCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicCard.swift; sourceTree = "<group>"; };
 		D076F9182D3544F0000278D5 /* SearchHistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryCell.swift; sourceTree = "<group>"; };
@@ -690,6 +693,7 @@
 		D0B3EC012CE227D900A8F321 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		D0C1F1E32CA440F200DD3D61 /* TopicCardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicCardModel.swift; sourceTree = "<group>"; };
 		D0C1F1E52CA4432F00DD3D61 /* TopicsWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsWidgetView.swift; sourceTree = "<group>"; };
+		D0D2C6922E13F85B00620DC2 /* DynamicLibraryWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicLibraryWrapper.swift; sourceTree = "<group>"; };
 		D0D655E72D26A79000571841 /* UIApplication+URLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+URLOpener.swift"; sourceTree = "<group>"; };
 		D0D9CB8F2D3024C00051EDDD /* SearchHistoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryItem.swift; sourceTree = "<group>"; };
 		D0D9CB902D3024C00051EDDD /* SearchItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchItem.swift; sourceTree = "<group>"; };
@@ -938,6 +942,7 @@
 		16A39A2F2DA9D71000C71F43 /* Wrappers */ = {
 			isa = PBXGroup;
 			children = (
+				D0D2C6922E13F85B00620DC2 /* DynamicLibraryWrapper.swift */,
 				1658CA682DDF56FE00622BC3 /* TimerWrapper.swift */,
 				16A39A2D2DA9D04100C71F43 /* AppAuthSessionWrapper.swift */,
 				16E912AE2DA72CAD00CD2049 /* OIDAuthorizationServiceWrapper.swift */,
@@ -1197,6 +1202,7 @@
 				5DC2506B2C91DB13009E9E7F /* Analytics */,
 				4EA1E27F2D8C611D0062453D /* Notifications */,
 				4EBCA3262DAC541B0063A723 /* LocalAuthorityService.swift */,
+				D06C49B52DE5D2510045C674 /* JailbreakDetectionService.swift */,
 				5DF32E082E045F5F006C63E0 /* AccessibilityAnnouncerService.swift */,
 			);
 			path = Services;
@@ -2297,6 +2303,7 @@
 				5D7D255F2D141CEC00BDC217 /* Redactor+Convenience.swift in Sources */,
 				5D4F97EB2BFF7725002CBDDE /* CoordinatorBuilder.swift in Sources */,
 				5DDD58892D5A556A001C0B3E /* NotificationOnboardingCoordinator.swift in Sources */,
+				D0D2C6932E13F87300620DC2 /* DynamicLibraryWrapper.swift in Sources */,
 				5DD4CB0F2D95485200459FB5 /* Date+Extensions.swift in Sources */,
 				D07E7A582DAE662A00B92D40 /* LocalAuthorityRepository.swift in Sources */,
 				5DD4CB102D95485200459FB5 /* DateFormatter+Convenience.swift in Sources */,
@@ -2385,6 +2392,7 @@
 				D0E85A842DDCD199003B4D7A /* AmbiguousAddressSelectionViewModel.swift in Sources */,
 				5DA6E5332C47BD2700D41263 /* DeeplinkRouteProvider.swift in Sources */,
 				5DFDEBF12CEE396D00F7A365 /* UserProperty+Convenience.swift in Sources */,
+				D06C49B62DE5D2510045C674 /* JailbreakDetectionService.swift in Sources */,
 				4E265D2A2DB0E6510089CF9E /* Authority.swift in Sources */,
 				D096BFF22E04124E00426C51 /* ChatItem.swift in Sources */,
 				4E265D2D2DB0E6510089CF9E /* LocalAuthorityAddress.swift in Sources */,

--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		D0C1F1E42CA440F200DD3D61 /* TopicCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C1F1E32CA440F200DD3D61 /* TopicCardModel.swift */; };
 		D0C1F1E62CA4434100DD3D61 /* TopicsWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C1F1E52CA4432F00DD3D61 /* TopicsWidgetView.swift */; };
 		D0D2C6932E13F87300620DC2 /* DynamicLibraryWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D2C6922E13F85B00620DC2 /* DynamicLibraryWrapper.swift */; };
+		D0D2C6952E13FBE000620DC2 /* JailbreakCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D2C6942E13FBE000620DC2 /* JailbreakCoordinator.swift */; };
 		D0D655E82D26A79000571841 /* UIApplication+URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D655E72D26A79000571841 /* UIApplication+URLOpener.swift */; };
 		D0D661A32D285D1B00571841 /* GOVKitTestUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = D0D661A22D285D1B00571841 /* GOVKitTestUtilities */; };
 		D0D9B0942D2C240E0051EDDD /* GOVKitTestUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = D0D9B0932D2C240E0051EDDD /* GOVKitTestUtilities */; };
@@ -694,6 +695,7 @@
 		D0C1F1E32CA440F200DD3D61 /* TopicCardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicCardModel.swift; sourceTree = "<group>"; };
 		D0C1F1E52CA4432F00DD3D61 /* TopicsWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsWidgetView.swift; sourceTree = "<group>"; };
 		D0D2C6922E13F85B00620DC2 /* DynamicLibraryWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicLibraryWrapper.swift; sourceTree = "<group>"; };
+		D0D2C6942E13FBE000620DC2 /* JailbreakCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JailbreakCoordinator.swift; sourceTree = "<group>"; };
 		D0D655E72D26A79000571841 /* UIApplication+URLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+URLOpener.swift"; sourceTree = "<group>"; };
 		D0D9CB8F2D3024C00051EDDD /* SearchHistoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryItem.swift; sourceTree = "<group>"; };
 		D0D9CB902D3024C00051EDDD /* SearchItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchItem.swift; sourceTree = "<group>"; };
@@ -1646,6 +1648,7 @@
 				5DFB48882DE9F7F600B41CDA /* ReLaunchCoordinator.swift */,
 				5DFB48892DE9F7F600B41CDA /* TopicOnboardingCoordinator.swift */,
 				5DFB488A2DE9F7F600B41CDA /* WelcomeOnboardingCoordinator.swift */,
+				D0D2C6942E13FBE000620DC2 /* JailbreakCoordinator.swift */,
 			);
 			path = Launch;
 			sourceTree = "<group>";
@@ -2405,6 +2408,7 @@
 				D0F681402DD4CF8E004421C0 /* LocalAuthorityExplainerViewModel.swift in Sources */,
 				3D9C933C2CB0155300EFA337 /* Bundle+AppVersionProvider.swift in Sources */,
 				D0ECB3FE2DCE0F0F00A9707E /* AmbiguousAuthoritySelectionView.swift in Sources */,
+				D0D2C6952E13FBE000620DC2 /* JailbreakCoordinator.swift in Sources */,
 				1687F3152CB40F8B005E1473 /* AllTopicsCoordinator.swift in Sources */,
 				4E4089882DBBEF78003ECB3B /* EditLocalAuthorityCoordinator.swift in Sources */,
 				4E00EEEF2CCB04B0007B61E8 /* TopicOnboardingViewModel.swift in Sources */,

--- a/Production/govuk_ios/Builders/CoordinatorBuilder.swift
+++ b/Production/govuk_ios/Builders/CoordinatorBuilder.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import UIKit
 import Foundation
 import Factory
@@ -106,6 +107,15 @@ class CoordinatorBuilder {
             notificationService: container.notificationService.resolve(),
             navigationController: navigationController,
             completion: completion
+        )
+    }
+
+    func jailbreakDetector(navigationController: UINavigationController,
+                           dismissAction: @escaping () -> Void) -> BaseCoordinator {
+        JailbreakCoordinator(
+            navigationController: navigationController,
+            jailbreakDetectionService: container.jailbreakDetectionService.resolve(),
+            dismissAction: dismissAction
         )
     }
 

--- a/Production/govuk_ios/Coordinators/Launch/JailbreakCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/Launch/JailbreakCoordinator.swift
@@ -1,0 +1,40 @@
+import Foundation
+import UIKit
+import SwiftUI
+
+class JailbreakCoordinator: BaseCoordinator {
+    private let jailbreakDetectionService: JailbreakDetectionServiceInterface
+    let dismissAction: () -> Void
+
+    init(navigationController: UINavigationController,
+         jailbreakDetectionService: JailbreakDetectionServiceInterface,
+         dismissAction: @escaping () -> Void) {
+        self.jailbreakDetectionService = jailbreakDetectionService
+        self.dismissAction = dismissAction
+        super.init(navigationController: navigationController)
+    }
+
+    override func start(url: URL?) {
+        guard jailbreakDetectionService.isJailbroken else {
+            return dismissAction()
+        }
+        setJailbreakDetectedViewController()
+    }
+
+    private func setJailbreakDetectedViewController() {
+        let viewModel = AppUnavailableContainerViewModel(
+            appLaunchService: nil,
+            dismissAction: dismissAction
+        )
+
+        let containerView = AppUnavailableContainerView(
+            viewModel: viewModel
+        )
+
+        let viewController = UIHostingController(
+            rootView: containerView
+        )
+
+        set(viewController)
+    }
+}

--- a/Production/govuk_ios/Coordinators/Launch/JailbreakCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/Launch/JailbreakCoordinator.swift
@@ -15,7 +15,7 @@ class JailbreakCoordinator: BaseCoordinator {
     }
 
     override func start(url: URL?) {
-        guard jailbreakDetectionService.isJailbroken else {
+        guard jailbreakDetectionService.isJailbroken() else {
             return dismissAction()
         }
         setJailbreakDetectedViewController()

--- a/Production/govuk_ios/Coordinators/Launch/PreAuthCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/Launch/PreAuthCoordinator.swift
@@ -14,7 +14,7 @@ class PreAuthCoordinator: BaseCoordinator {
     }
 
     override func start(url: URL?) {
-        startLaunch(url: url)
+        startJailbreakDetection(url: url)
     }
 
     private func startLaunch(url: URL?) {
@@ -24,6 +24,18 @@ class PreAuthCoordinator: BaseCoordinator {
                 self?.startAnalyticsConsent(
                     url: url,
                     launchResponse: response
+                )
+            }
+        )
+        start(coordinator)
+    }
+
+    private func startJailbreakDetection(url: URL?) {
+        let coordinator = coordinatorBuilder.jailbreakDetector(
+            navigationController: root,
+            dismissAction: { [weak self] in
+                self?.startLaunch(
+                    url: url
                 )
             }
         )

--- a/Production/govuk_ios/Extensions/Container/Container+Services.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+Services.swift
@@ -212,4 +212,12 @@ extension Container {
             )
         }
     }
+
+    var jailbreakDetectionService: Factory<JailbreakDetectionServiceInterface> {
+        Factory(self) {
+            JailbreakDetectionService(
+                urlOpener: UIApplication.shared
+            )
+        }
+    }
 }

--- a/Production/govuk_ios/Services/JailbreakDetectionService.swift
+++ b/Production/govuk_ios/Services/JailbreakDetectionService.swift
@@ -72,10 +72,9 @@ final class JailbreakDetectionService: JailbreakDetectionServiceInterface {
 
     func checkURLSchemes() -> Bool {
         for urlScheme in Self.forbiddenURLSchemes {
-            if let url = URL(string: urlScheme) {
-                if urlOpener.canOpenURL(url) {
-                    return true
-                }
+            if let url = URL(string: urlScheme),
+               urlOpener.canOpenURL(url) {
+                return true
             }
         }
         return false

--- a/Production/govuk_ios/Services/JailbreakDetectionService.swift
+++ b/Production/govuk_ios/Services/JailbreakDetectionService.swift
@@ -3,7 +3,7 @@ import GOVKit
 import MachO
 
 protocol JailbreakDetectionServiceInterface {
-    var isJailbroken: Bool { get }
+    func isJailbroken() -> Bool
 }
 
 final class JailbreakDetectionService: JailbreakDetectionServiceInterface {
@@ -19,7 +19,8 @@ final class JailbreakDetectionService: JailbreakDetectionServiceInterface {
         self.urlOpener = urlOpener
     }
 
-    var isJailbroken: Bool {
+    @inline(__always)
+    func isJailbroken() -> Bool {
         #if targetEnvironment(simulator)
             return false
         #else

--- a/Production/govuk_ios/Services/JailbreakDetectionService.swift
+++ b/Production/govuk_ios/Services/JailbreakDetectionService.swift
@@ -1,0 +1,205 @@
+import UIKit
+import GOVKit
+import MachO
+
+protocol JailbreakDetectionServiceInterface {
+    var isJailbroken: Bool { get }
+}
+
+final class JailbreakDetectionService: JailbreakDetectionServiceInterface {
+    private let fileManager: FileManagerInterface
+    private let dynamicLibrary: DynamicLibraryInterface
+    private let urlOpener: URLOpener
+
+    init(fileManager: FileManagerInterface = FileManager.default,
+         dynamicLibrary: DynamicLibraryInterface = DynamicLibraryInterfaceWrapper(),
+         urlOpener: URLOpener) {
+        self.fileManager = fileManager
+        self.dynamicLibrary = dynamicLibrary
+        self.urlOpener = urlOpener
+    }
+
+    var isJailbroken: Bool {
+        #if targetEnvironment(simulator)
+            return false
+        #else
+            let result = checkFiles() ||
+            checkDynamicLibraries() ||
+            checkSandboxPriveleges() ||
+            checkURLSchemes()
+        return result
+        #endif
+    }
+
+    func checkFiles() -> Bool {
+        return !Self.forbiddenFiles.allSatisfy { !fileManager.fileExists(atPath: $0) }
+    }
+
+    func checkDynamicLibraries() -> Bool {
+        for index in 0..<dynamicLibrary.dyldImageCount() {
+            guard let imageName = dynamicLibrary.dyldGetImageName(index),
+                  let libraryName = String(validatingUTF8: imageName) else {
+                continue
+            }
+
+            let lowercasedLibraryName = libraryName.lowercased()
+            if Self.forbiddenDYLD.contains(
+                where: { lowercasedLibraryName.contains($0) }
+            ) {
+                return true
+            }
+        }
+        return false
+    }
+
+    func checkSandboxPriveleges() -> Bool {
+        let testText = "Jailbreak test"
+        for path in Self.forbiddenPaths {
+            do {
+                try testText.write(
+                    toFile: path,
+                    atomically: true,
+                    encoding: .utf8
+                )
+                try? fileManager.removeItem(atPath: path)
+                return true
+            } catch {
+                continue
+            }
+        }
+        return false
+    }
+
+    func checkURLSchemes() -> Bool {
+        for urlScheme in Self.forbiddenURLSchemes {
+            if let url = URL(string: urlScheme) {
+                if urlOpener.canOpenURL(url) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private static var forbiddenFiles: [String] {
+        [
+            "/.bootstrapped_electra",
+            "/.cydia_no_stash",
+            "/.installed_unc0ver",
+            "/Applications/blackra1n.app",
+            "/Applications/Cydia.app",
+            "/Applications/FakeCarrier.app",
+            "/Applications/HideJB.app",
+            "/Applications/Icy.app",
+            "/Applications/IntelliScreen.app",
+            "/Applications/MxTube.app",
+            "/Applications/RockApp.app",
+            "/Applications/SBSettings.app",
+            "/Applications/SBSetttings.app",
+            "/Applications/Sileo.app",
+            "/Applications/Snoop-itConfig.app",
+            "/Applications/WinterBoard.app",
+            "/bin.sh",
+            "/bin/bash",
+            "/bin/sh",
+            "/etc/apt",
+            "/etc/apt/sources.list.d/electra.list",
+            "/etc/apt/sources.list.d/sileo.sources",
+            "/etc/apt/undecimus/undecimus.list",
+            "/etc/ssh/sshd_config",
+            "/jb/amfid_payload.dylib",
+            "/jb/jailbreakd.plist",
+            "/jb/libjailbreak.dylib",
+            "/jb/lzma",
+            "/jb/offsets.plist",
+            "/Library/dpkg/info/re.frida.server.list",
+            "/Library/LaunchDaemons/re.frida.server.plist",
+            "/Library/MobileSubstrate/CydiaSubstrate.dylib",
+            "/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
+            "/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
+            "/Library/MobileSubstrate/HideJB.dylib",
+            "/Library/MobileSubstrate/MobileSubstrate.dylib",
+            "/Library/PreferenceBundles/ABypassPrefs.bundle",
+            "/Library/PreferenceBundles/FlyJBPrefs.bundle",
+            "/Library/PreferenceBundles/HideJBPrefs.bundle",
+            "/Library/PreferenceBundles/LibertyPref.bundle",
+            "/Library/PreferenceBundles/ShadowPreferences.bundle",
+            "/private/etc/apt",
+            "/private/etc/dpkg/origins/debian",
+            "/private/etc/ssh/sshd_config",
+            "/private/var/cache/apt/",
+            "/private/var/lib/apt",
+            "/private/var/lib/apt/",
+            "/private/var/lib/cydia",
+            "/private/var/log/syslog",
+            "/private/var/mobile/Library/SBSettings/Themes",
+            "/private/var/mobileLibrary/SBSettingsThemes/",
+            "/private/var/stash",
+            "/private/var/tmp/cydia.log",
+            "/private/var/Users/",
+            "/System/Library/LaunchDaemons/com.ikey.bbot.plist",
+            "/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
+            "/usr/bin/cycript",
+            "/usr/bin/ssh",
+            "/usr/bin/sshd",
+            "/usr/lib/libcycript.dylib",
+            "/usr/lib/libhooker.dylib",
+            "/usr/lib/libjailbreak.dylib",
+            "/usr/lib/libsubstitute.dylib",
+            "/usr/lib/substrate",
+            "/usr/lib/TweakInject",
+            "/usr/libexec/cydia/",
+            "/usr/libexec/cydia/firmware.sh",
+            "/usr/libexec/sftp-server",
+            "/usr/libexec/ssh-keysign",
+            "/usr/local/bin/cycript",
+            "/usr/sbin/frida-server",
+            "/usr/sbin/sshd",
+            "/usr/share/jailbreak/injectme.plist",
+            "/var/binpack",
+            "/var/cache/apt",
+            "/var/checkra1n.dmg",
+            "/var/lib/apt",
+            "/var/lib/cydia",
+            "/var/lib/dpkg/info/mobilesubstrate.md5sums",
+            "/var/log/apt",
+            "/var/log/syslog",
+            "/var/tmp/cydia.log"
+        ]
+    }
+
+    private static var forbiddenPaths: [String] {
+        [
+            "/",
+            "/root/",
+            "/private/",
+            "/jb/"
+        ]
+    }
+
+    private static var forbiddenDYLD: [String] {
+        [
+            "fridagadget",
+            "frida",
+            "cynject",
+            "libcycript"
+        ]
+    }
+
+    private static var forbiddenURLSchemes: [String] {
+        [
+            "undecimus://",
+            "sileo://",
+            "zbra://",
+            "filza://",
+            "cydia://"
+        ]
+    }
+}
+
+protocol FileManagerInterface {
+    func fileExists(atPath: String) -> Bool
+    func removeItem(atPath path: String) throws
+}
+
+extension FileManager: FileManagerInterface {}

--- a/Production/govuk_ios/ViewModels/AppUnavailableContainerViewModel.swift
+++ b/Production/govuk_ios/ViewModels/AppUnavailableContainerViewModel.swift
@@ -5,7 +5,7 @@ import GOVKit
 
 class AppUnavailableContainerViewModel: ObservableObject {
     private let urlOpener: URLOpener
-    private let appLaunchService: AppLaunchServiceInterface
+    private let appLaunchService: AppLaunchServiceInterface?
     let error: AppConfigError?
     private let dismissAction: () -> Void
     @Published var showProgressView: Bool = false
@@ -31,7 +31,7 @@ class AppUnavailableContainerViewModel: ObservableObject {
     }
 
     init(urlOpener: URLOpener = UIApplication.shared,
-         appLaunchService: AppLaunchServiceInterface,
+         appLaunchService: AppLaunchServiceInterface?,
          error: AppConfigError? = nil,
          dismissAction: @escaping () -> Void) {
         self.urlOpener = urlOpener
@@ -56,7 +56,7 @@ class AppUnavailableContainerViewModel: ObservableObject {
 
     private func retry() {
         showProgressView = true
-        appLaunchService.fetch { [weak self] result in
+        appLaunchService?.fetch { [weak self] result in
             if case .success = result.configResult {
                 self?.dismissAction()
             }

--- a/Production/govuk_ios/Wrappers/DynamicLibraryWrapper.swift
+++ b/Production/govuk_ios/Wrappers/DynamicLibraryWrapper.swift
@@ -2,16 +2,14 @@ import MachO
 
 protocol DynamicLibraryInterface {
     func dyldImageCount() -> UInt32
-    // swiftlint:disable:next identifier_name
-    func dyldGetImageName(_ image_index: UInt32) -> UnsafePointer<CChar>!
+    func dyldGetImageName(_ imageIndex: UInt32) -> UnsafePointer<CChar>!
 }
 
 final class DynamicLibraryInterfaceWrapper: DynamicLibraryInterface {
     func dyldImageCount() -> UInt32 {
         return MachO._dyld_image_count()
     }
-    // swiftlint:disable:next identifier_name
-    func dyldGetImageName(_ image_index: UInt32) -> UnsafePointer<CChar>! {
-        return MachO._dyld_get_image_name(image_index)
+    func dyldGetImageName(_ imageIndex: UInt32) -> UnsafePointer<CChar>! {
+        return MachO._dyld_get_image_name(imageIndex)
     }
 }

--- a/Production/govuk_ios/Wrappers/DynamicLibraryWrapper.swift
+++ b/Production/govuk_ios/Wrappers/DynamicLibraryWrapper.swift
@@ -1,0 +1,17 @@
+import MachO
+
+protocol DynamicLibraryInterface {
+    func dyldImageCount() -> UInt32
+    // swiftlint:disable:next identifier_name
+    func dyldGetImageName(_ image_index: UInt32) -> UnsafePointer<CChar>!
+}
+
+final class DynamicLibraryInterfaceWrapper: DynamicLibraryInterface {
+    func dyldImageCount() -> UInt32 {
+        return MachO._dyld_image_count()
+    }
+    // swiftlint:disable:next identifier_name
+    func dyldGetImageName(_ image_index: UInt32) -> UnsafePointer<CChar>! {
+        return MachO._dyld_get_image_name(image_index)
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockCoordinatorBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockCoordinatorBuilder.swift
@@ -77,6 +77,17 @@ class MockCoordinatorBuilder: CoordinatorBuilder {
         )
     }
 
+    var _stubbedJailbreakCoordinator: BaseCoordinator?
+    var _receivedJailbreakDismissAction: (() -> Void)?
+    override func jailbreakDetector(navigationController: UINavigationController,
+                                    dismissAction: @escaping () -> Void) -> BaseCoordinator {
+        _receivedJailbreakDismissAction = dismissAction
+        return _stubbedJailbreakCoordinator ??
+        MockBaseCoordinator(
+            navigationController: .init()
+        )
+    }
+
     var _stubbedAnalyticsConsentCoordinator: BaseCoordinator?
     var _receivedAnalyticsConsentNavigationController: UINavigationController?
     var _receivedAnalyticsConsentCompletion: (() -> Void)?

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Foundation/MockFileManager.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Foundation/MockFileManager.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+@testable import govuk_ios
+
+class MockFileManager: FileManagerInterface {
+
+    var _removedPath: String?
+    func removeItem(atPath path: String) throws {
+        _removedPath = path
+    }
+    
+
+    var _stubbedFilePaths: [String] = []
+    func fileExists(atPath: String) -> Bool {
+        _stubbedFilePaths.contains(atPath)
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Jailbreak/MockDynamicLibrary.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Jailbreak/MockDynamicLibrary.swift
@@ -9,7 +9,7 @@ final class MockDynamicLibrary: DynamicLibraryInterface {
     }
 
     var _stubbedImageName: String = ""
-    func dyldGetImageName(_ image_index: UInt32) -> UnsafePointer<CChar>! {
+    func dyldGetImageName(_ imageIndex: UInt32) -> UnsafePointer<CChar>! {
         _stubbedImageName.withCString { ptr in
             return ptr
         }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Jailbreak/MockDynamicLibrary.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Jailbreak/MockDynamicLibrary.swift
@@ -1,0 +1,17 @@
+import Foundation
+@testable import govuk_ios
+
+final class MockDynamicLibrary: DynamicLibraryInterface {
+
+    var _stubbedDyldImageCount: UInt32 = 0
+    func dyldImageCount() -> UInt32 {
+        _stubbedDyldImageCount
+    }
+
+    var _stubbedImageName: String = ""
+    func dyldGetImageName(_ image_index: UInt32) -> UnsafePointer<CChar>! {
+        _stubbedImageName.withCString { ptr in
+            return ptr
+        }
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Jailbreak/MockJailbreakURLOpener.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Jailbreak/MockJailbreakURLOpener.swift
@@ -2,26 +2,25 @@ import UIKit
 
 @testable import GOVKit
 
-class MockURLOpener: URLOpener {
+class MockJailbreakURLOpener: URLOpener {
 
-    var _receivedCanOpennUrl: URL?
-    var _stubbedCanOpenResult: Bool = true
+    var _openableURLS: [String] = []
     func canOpenURL(_ url: URL) -> Bool {
-        _receivedCanOpennUrl = url
-        return _stubbedCanOpenResult
+        let urls = _openableURLS.compactMap { URL(string: $0) }
+        return urls.contains(url)
     }
 
     var _stubbedOpenResult: Bool = true
-    
     var _receivedOpenIfPossibleUrl: URL?
     func openIfPossible(_ url: URL) -> Bool {
         _receivedOpenIfPossibleUrl = url
         return _stubbedOpenResult
     }
-    
+
     var _receivedOpenIfPossibleUrlString: String?
     func openIfPossible(_ urlString: String) -> Bool {
         _receivedOpenIfPossibleUrlString = urlString
         return _stubbedOpenResult
     }
+
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Services/MockJailbreakDetectionService.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Services/MockJailbreakDetectionService.swift
@@ -4,7 +4,7 @@ import Foundation
 
 final class MockJailbreakDetectionService: JailbreakDetectionServiceInterface {
     var _stubbedIsJailbroken: Bool = false
-    var isJailbroken: Bool {
+    func isJailbroken() -> Bool {
         return _stubbedIsJailbroken
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Services/MockJailbreakDetectionService.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Services/MockJailbreakDetectionService.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+@testable import govuk_ios
+
+final class MockJailbreakDetectionService: JailbreakDetectionServiceInterface {
+    var _stubbedIsJailbroken: Bool = false
+    var isJailbroken: Bool {
+        return _stubbedIsJailbroken
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/CoordinatorBuilderTests.swift
@@ -86,6 +86,17 @@ struct CoordinatorBuilderTests {
     }
 
     @Test
+    func jailbreak_returnsExpectedResult() {
+        let subject = CoordinatorBuilder(container: Container())
+        let coordinator = subject.jailbreakDetector(
+            navigationController: MockNavigationController(),
+            dismissAction: {}
+        )
+
+        #expect(coordinator is JailbreakCoordinator)
+    }
+    
+    @Test
     func appUnavailable_returnsExpectedResult() {
         let subject = CoordinatorBuilder(container: Container())
         let coordinator = subject.appUnavailable(

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/JailbreakCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/JailbreakCoordinatorTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import UIKit
+import Testing
+
+@testable import govuk_ios
+
+@Suite
+@MainActor
+struct JailbreakCoordinatorTests {
+
+    @Test
+    func start_isJailbroken_false_callsDismiss() async throws {
+        await withCheckedContinuation { continuation in
+            let sut = JailbreakCoordinator(
+                navigationController: UINavigationController(),
+                jailbreakDetectionService: MockJailbreakDetectionService(),
+                dismissAction: {
+                    continuation.resume()
+                }
+            )
+            sut.start()
+        }
+    }
+
+    @Test
+    func start_isJailbroken_true_doesNotCallDismiss() async throws {
+        let jailbreakService = MockJailbreakDetectionService()
+        jailbreakService._stubbedIsJailbroken = true
+        let result: Bool = try await withCheckedThrowingContinuation { continuation in
+            let sut = JailbreakCoordinator(
+                navigationController: UINavigationController(),
+                jailbreakDetectionService: jailbreakService,
+                dismissAction: {
+                    continuation.resume(throwing: TestError.unexpectedMethodCalled)
+                }
+            )
+            sut.start()
+            continuation.resume(returning: true)
+        }
+        #expect(result)
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/PreAuthCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/PreAuthCoordinatorTests.swift
@@ -10,8 +10,26 @@ import UIKit
 struct PreAuthCoordinatorTests {
 
     @Test
-    func start_startsLaunchCoordinator() {
+    func start_startsJailbreakCoordinator() {
         let mockCoordinatorBuilder = MockCoordinatorBuilder.mock
+        let stubbedJailbreakCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedJailbreakCoordinator = stubbedJailbreakCoordinator
+        let subject = PreAuthCoordinator(
+            coordinatorBuilder: mockCoordinatorBuilder,
+            navigationController: MockNavigationController(),
+            completion: { }
+        )
+
+        subject.start(url: nil)
+
+        #expect(stubbedJailbreakCoordinator._startCalled)
+    }
+
+    @Test
+    func jailbreakCompletion_startsLaunchCoordinator() async throws {
+        let mockCoordinatorBuilder = MockCoordinatorBuilder.mock
+        let stubbedJailbreakCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedJailbreakCoordinator = stubbedJailbreakCoordinator
         let stubbedLaunchCoordinator = MockBaseCoordinator()
         mockCoordinatorBuilder._stubbedLaunchCoordinator = stubbedLaunchCoordinator
         let subject = PreAuthCoordinator(
@@ -22,12 +40,16 @@ struct PreAuthCoordinatorTests {
 
         subject.start(url: nil)
 
+        mockCoordinatorBuilder._receivedJailbreakDismissAction?()
+
         #expect(stubbedLaunchCoordinator._startCalled)
     }
 
     @Test
     func launchCompletion_startsAnalyticsConsent() {
         let mockCoordinatorBuilder = MockCoordinatorBuilder.mock
+        let stubbedJailbreakCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedJailbreakCoordinator = stubbedJailbreakCoordinator
         let stubbedLaunchCoordinator = MockBaseCoordinator()
         mockCoordinatorBuilder._stubbedLaunchCoordinator = stubbedLaunchCoordinator
         let stubbedAnalyticsConsentCoordinator = MockBaseCoordinator()
@@ -40,6 +62,7 @@ struct PreAuthCoordinatorTests {
 
         subject.start(url: nil)
 
+        mockCoordinatorBuilder._receivedJailbreakDismissAction?()
         mockCoordinatorBuilder._receivedLaunchCompletion?(.arrangeAvailable)
 
         #expect(stubbedAnalyticsConsentCoordinator._startCalled)
@@ -48,6 +71,8 @@ struct PreAuthCoordinatorTests {
     @Test
     func analyticsCompletion_startsNotificationConsentCheck() {
         let mockCoordinatorBuilder = MockCoordinatorBuilder.mock
+        let stubbedJailbreakCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedJailbreakCoordinator = stubbedJailbreakCoordinator
         let stubbedLaunchCoordinator = MockBaseCoordinator()
         mockCoordinatorBuilder._stubbedLaunchCoordinator = stubbedLaunchCoordinator
         let stubbedAnalyticsConsentCoordinator = MockBaseCoordinator()
@@ -61,6 +86,8 @@ struct PreAuthCoordinatorTests {
         )
 
         subject.start(url: nil)
+
+        mockCoordinatorBuilder._receivedJailbreakDismissAction?()
         let expectedLaunchResponse = AppLaunchResponse.arrangeAvailable
         mockCoordinatorBuilder._receivedLaunchCompletion?(expectedLaunchResponse)
         mockCoordinatorBuilder._receivedAnalyticsConsentCompletion?()
@@ -72,6 +99,8 @@ struct PreAuthCoordinatorTests {
     @Test
     func notificationConsentCheckCompletion_startsAppForcedUpdate() {
         let mockCoordinatorBuilder = MockCoordinatorBuilder.mock
+        let stubbedJailbreakCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedJailbreakCoordinator = stubbedJailbreakCoordinator
         let stubbedLaunchCoordinator = MockBaseCoordinator()
         mockCoordinatorBuilder._stubbedLaunchCoordinator = stubbedLaunchCoordinator
         let stubbedAnalyticsConsentCoordinator = MockBaseCoordinator()
@@ -89,6 +118,7 @@ struct PreAuthCoordinatorTests {
 
         subject.start(url: nil)
 
+        mockCoordinatorBuilder._receivedJailbreakDismissAction?()
         let expectedLaunchResponse = AppLaunchResponse.arrangeAvailable
         mockCoordinatorBuilder._receivedLaunchCompletion?(expectedLaunchResponse)
         mockCoordinatorBuilder._receivedAnalyticsConsentCompletion?()
@@ -101,6 +131,8 @@ struct PreAuthCoordinatorTests {
     @Test
     func appForcedUpdateCompletion_startsAppUnavailable() {
         let mockCoordinatorBuilder = MockCoordinatorBuilder.mock
+        let stubbedJailbreakCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedJailbreakCoordinator = stubbedJailbreakCoordinator
         let stubbedLaunchCoordinator = MockBaseCoordinator()
         mockCoordinatorBuilder._stubbedLaunchCoordinator = stubbedLaunchCoordinator
         let stubbedAnalyticsConsentCoordinator = MockBaseCoordinator()
@@ -120,6 +152,7 @@ struct PreAuthCoordinatorTests {
 
         subject.start(url: nil)
 
+        mockCoordinatorBuilder._receivedJailbreakDismissAction?()
         let expectedLaunchResponse = AppLaunchResponse.arrangeAvailable
         mockCoordinatorBuilder._receivedLaunchCompletion?(expectedLaunchResponse)
         mockCoordinatorBuilder._receivedAnalyticsConsentCompletion?()
@@ -133,6 +166,8 @@ struct PreAuthCoordinatorTests {
     @Test
     func appUnavailableCompletion_startsAppRecommendUpdate() {
         let mockCoordinatorBuilder = MockCoordinatorBuilder.mock
+        let stubbedJailbreakCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedJailbreakCoordinator = stubbedJailbreakCoordinator
         let stubbedLaunchCoordinator = MockBaseCoordinator()
         mockCoordinatorBuilder._stubbedLaunchCoordinator = stubbedLaunchCoordinator
         let stubbedAnalyticsConsentCoordinator = MockBaseCoordinator()
@@ -154,6 +189,7 @@ struct PreAuthCoordinatorTests {
 
         subject.start(url: nil)
 
+        mockCoordinatorBuilder._receivedJailbreakDismissAction?()
         let expectedLaunchResponse = AppLaunchResponse.arrangeAvailable
         mockCoordinatorBuilder._receivedLaunchCompletion?(.arrangeAvailable)
         mockCoordinatorBuilder._receivedAnalyticsConsentCompletion?()
@@ -169,6 +205,8 @@ struct PreAuthCoordinatorTests {
     @Test
     func appRecommendUpdateCompletion_completesCoordinator() {
         let mockCoordinatorBuilder = MockCoordinatorBuilder.mock
+        let stubbedJailbreakCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedJailbreakCoordinator = stubbedJailbreakCoordinator
         let stubbedLaunchCoordinator = MockBaseCoordinator()
         mockCoordinatorBuilder._stubbedLaunchCoordinator = stubbedLaunchCoordinator
         let stubbedAnalyticsConsentCoordinator = MockBaseCoordinator()
@@ -193,6 +231,7 @@ struct PreAuthCoordinatorTests {
 
         subject.start(url: nil)
 
+        mockCoordinatorBuilder._receivedJailbreakDismissAction?()
         mockCoordinatorBuilder._receivedLaunchCompletion?(.arrangeAvailable)
         mockCoordinatorBuilder._receivedAnalyticsConsentCompletion?()
         mockCoordinatorBuilder._receivedNotificationConsentCompletion?()

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/JailbreakDetectionServiceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/JailbreakDetectionServiceTests.swift
@@ -1,0 +1,114 @@
+import UIKit
+import Testing
+
+@testable import GOVKitTestUtilities
+@testable import govuk_ios
+
+final class JailbreakDetectionServiceTests {
+
+    var mockFileManager: MockFileManager!
+    var mockURLOpener: MockJailbreakURLOpener!
+    var mockDyamicLibrary: MockDynamicLibrary!
+
+    init() {
+        mockFileManager = MockFileManager()
+        mockURLOpener = MockJailbreakURLOpener()
+        mockDyamicLibrary = MockDynamicLibrary()
+    }
+
+    deinit {
+        mockFileManager = nil
+        mockURLOpener = nil
+        mockDyamicLibrary = nil
+    }
+
+    @Test
+    func forbiddenFileDetected_returnsCorrectResult() {
+        mockFileManager._stubbedFilePaths = [
+            "/Applications/Cydia.app",
+            "/Applications/Harmless.app"
+        ]
+
+        let sut = JailbreakDetectionService(
+            fileManager: mockFileManager,
+            urlOpener: mockURLOpener
+        )
+
+        #expect(sut.checkFiles())
+    }
+
+    @Test
+    func noForbiddenFileDetected_returnsCorrectResult() {
+        mockFileManager._stubbedFilePaths = [
+            "/Applications/Benign.app",
+            "/Applications/Harmless.app"
+        ]
+
+        let sut = JailbreakDetectionService(
+            fileManager: mockFileManager,
+            urlOpener: mockURLOpener
+        )
+        
+        #expect(!sut.checkFiles())
+    }
+
+    @Test
+    func forbiddenURLDetected_returnsCorrectResult() {
+        mockURLOpener._openableURLS = ["cydia://"]
+        
+        let sut = JailbreakDetectionService(
+            fileManager: mockFileManager,
+            urlOpener: mockURLOpener
+        )
+        
+        #expect(sut.checkURLSchemes())
+    }
+
+    @Test
+    func allowedURLDetected_returnsCorrectResult() {
+        mockURLOpener._openableURLS = ["govuk://services"]
+
+        let sut = JailbreakDetectionService(
+            fileManager: mockFileManager,
+            urlOpener: mockURLOpener
+        )
+
+        #expect(!sut.checkURLSchemes())
+    }
+
+    @Test
+    func fileSystemPrivileges_returnsCorrectResult() {
+        let sut = JailbreakDetectionService(
+            fileManager: mockFileManager,
+            urlOpener: mockURLOpener
+        )
+
+        #expect(!sut.checkSandboxPriveleges())
+    }
+
+    @Test
+    func forbiddenDynamicLibraries_returnsCorrectResult() {
+        mockDyamicLibrary._stubbedDyldImageCount = 1
+        mockDyamicLibrary._stubbedImageName = "FridaGadget"
+        let sut = JailbreakDetectionService(
+            fileManager: mockFileManager,
+            dynamicLibrary: mockDyamicLibrary,
+            urlOpener: mockURLOpener
+        )
+        
+        #expect(sut.checkDynamicLibraries())
+    }
+
+    @Test
+    func noForbiddenDynamicLibraries_returnsCorrectResult() {
+        mockDyamicLibrary._stubbedDyldImageCount = 1
+        mockDyamicLibrary._stubbedImageName = "BenignLibrary"
+        let sut = JailbreakDetectionService(
+            fileManager: mockFileManager,
+            dynamicLibrary: mockDyamicLibrary,
+            urlOpener: mockURLOpener
+        )
+
+        #expect(!sut.checkDynamicLibraries())
+    }
+}


### PR DESCRIPTION
Add a jailbreak detection service, which tests for the presence of forbidden files, libraries, and device permissions.
Service is called first thing on launch, and if a jailbreak is detected, the "app not available" screen is shown