### PR TITLE
Feature/Add clear chat alert

### DIFF
--- a/Production/govuk_ios/Resources/Strings/Chat.xcstrings
+++ b/Production/govuk_ios/Resources/Strings/Chat.xcstrings
@@ -23,6 +23,50 @@
         }
       }
     },
+    "clearAlertBodyText" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This will delete your chat history."
+          }
+        }
+      }
+    },
+    "clearAlertConfirmTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yes, clear chat"
+          }
+        }
+      }
+    },
+    "clearAlertDenyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No, not now"
+          }
+        }
+      }
+    },
+    "clearAlertTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Do you want to clear your chat history?"
+          }
+        }
+      }
+    },
     "clearMenuTitle" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Production/govuk_ios/Views/Chat/ChatActionView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatActionView.swift
@@ -6,6 +6,7 @@ struct ChatActionView: View {
     @State private var textViewHeight: CGFloat = 50.0
     @State private var placeholderText: String? = String.chat.localized("textEditorPlaceholder")
     @State private var charactersCountHeight: CGFloat = 0
+    @State private var showClearChatAlert = false
     private var animationDuration = 0.3
 
     init(viewModel: ChatViewModel,
@@ -50,9 +51,13 @@ struct ChatActionView: View {
 
     private var menuView: some View {
         return Menu {
-            Button(role: .destructive, action: clearChat) {
-                Label(String.chat.localized("clearMenuTitle"), systemImage: "trash")
-            }
+            Button(
+                role: .destructive,
+                action: { showClearChatAlert = true },
+                label: {
+                    Label(String.chat.localized("clearMenuTitle"), systemImage: "trash")
+                }
+            )
             Button(action: showAbout) {
                 Label(String.chat.localized("aboutMenuTitle"), systemImage: "info.circle")
             }
@@ -75,6 +80,21 @@ struct ChatActionView: View {
         }
         .accessibilityLabel(String.chat.localized("moreOptionsAccessibilityLabel"))
         .accessibilitySortPriority(0)
+        .alert(isPresented: $showClearChatAlert) {
+            Alert(
+                title: Text(String.chat.localized("clearAlertTitle")),
+                message: Text(String.chat.localized("clearAlertBodyText")),
+                primaryButton: .destructive(
+                    Text(String.chat.localized("clearAlertConfirmTitle")),
+                    action: {
+                        viewModel.newChat()
+                    }
+                ),
+                secondaryButton: .cancel(
+                    Text(String.chat.localized("clearAlertDenyTitle"))
+                )
+            )
+        }
     }
 
     private func textEditorView(maxFrameHeight: CGFloat) -> some View {
@@ -245,10 +265,6 @@ struct ChatActionView: View {
 
     private func showAbout() {
         print("About tapped")
-    }
-
-    private func clearChat() {
-        viewModel.newChat()
     }
 }
 


### PR DESCRIPTION
Clearing chats wipes conversation id and removes all chat cells.

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 18 5 - 2025-07-23 at 16 04 23" src="https://github.com/user-attachments/assets/c0ff3fce-2f12-4f30-aae2-026e4b4d32c7" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 18 5 - 2025-07-23 at 16 04 27" src="https://github.com/user-attachments/assets/507160a1-6b71-4532-a373-50000b2834f6" />
