### PR TITLE
Logic fixes for loading history

### DIFF
--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -83,9 +83,9 @@ class ChatViewModel: ObservableObject {
 
     func loadHistory() {
         guard let conversationId = chatService.currentConversationId else {
+            cellModels.removeAll()
             return
         }
-        cellModels.removeAll()
         requestInFlight = true
         chatService.chatHistory(
             conversationId: conversationId
@@ -129,7 +129,9 @@ class ChatViewModel: ObservableObject {
             cellModels.append(answer)
         }
         if let pendingQuestion = history.pendingQuestion {
-            askQuestion(pendingQuestion.message)
+            let question = ChatCellViewModel(question: pendingQuestion)
+            cellModels.append(question)
+            pollForAnswer(pendingQuestion)
         }
     }
 

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.ChatViewControllerSnapshotTests/test_loadInNavigationController_showError_dark_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.ChatViewControllerSnapshotTests/test_loadInNavigationController_showError_dark_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:720cf5acb6d1d78379e9feeb3046d111caf71a2ae94adc27d47ccb28db52fadf
-size 267394
+oid sha256:1a14012f09e425b27cb504f696d77da831a650fa5d4dd09ffb76b29546cc05f5
+size 279828

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.ChatViewControllerSnapshotTests/test_loadInNavigationController_showError_light_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.ChatViewControllerSnapshotTests/test_loadInNavigationController_showError_light_rendersCorrectly@3x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5271e5785d9575a9c362e15ad91238b252fb0ad5ffabb6dad5eb1e06028b0626
-size 262660
+oid sha256:c3334e9e55ed635eebb75966a800f08e01728e0d117b6782d6e523198da86405
+size 273585

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/ChatViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/ChatViewControllerSnapshotTests.swift
@@ -75,7 +75,7 @@ final class ChatViewControllerSnapshotTests: SnapshotTestCase {
             conversationId: conversationId,
             createdAt: createdAt,
             id: "78910",
-            message: showError ? "steve@apple.com" : "This is the pending question"
+            message: "This is the pending question"
         )
 
         let history = History(
@@ -95,6 +95,10 @@ final class ChatViewControllerSnapshotTests: SnapshotTestCase {
             handleError: { _ in }
         )
 
+        if showError {
+            viewModel.errorText = String.chat.localized("validationErrorText")
+        }
+        
         viewModel.cellModels.append(.gettingAnswer)
         let view = ChatView(viewModel: viewModel)
             .environment(\.isTesting, true)


### PR DESCRIPTION
Have history start polling for pending question instead of asking it again (which resulted in a validation error)

If attempting to load history and there is no conversationId (i.e., starting new convo), clear the chat.