### PR TITLE
Read chatPollingIntervalSeconds from configuration

### DIFF
--- a/Production/govuk_ios/Model/AppConfig/Config.swift
+++ b/Production/govuk_ios/Model/AppConfig/Config.swift
@@ -8,4 +8,5 @@ struct Config: Decodable {
     let lastUpdated: String
     let searchApiUrl: String?
     var authenticationIssuerBaseUrl: String?
+    let chatPollIntervalSeconds: Int?
 }

--- a/Production/govuk_ios/ServiceClients/Chat/ChatServiceClient.swift
+++ b/Production/govuk_ios/ServiceClients/Chat/ChatServiceClient.swift
@@ -22,7 +22,6 @@ enum ChatError: LocalizedError {
     case apiUnavailable
     case decodingError
     case validationError
-    case maxRetriesExceeded
 }
 
 struct ChatServiceClient: ChatServiceClientInterface {

--- a/Production/govuk_ios/Services/AppConfigService.swift
+++ b/Production/govuk_ios/Services/AppConfigService.swift
@@ -5,12 +5,16 @@ import GOVKit
 protocol AppConfigServiceInterface {
     func fetchAppConfig(completion: @escaping FetchAppConfigCompletion)
     func isFeatureEnabled(key: Feature) -> Bool
+    var chatPollIntervalSeconds: TimeInterval { get }
 }
 
 public final class AppConfigService: AppConfigServiceInterface {
     private var featureFlags: [String: Bool] = [:]
 
     private let appConfigServiceClient: AppConfigServiceClientInterface
+    private var retryInterval: Int?
+
+    var chatPollIntervalSeconds: TimeInterval = 3.0
 
     init(appConfigServiceClient: AppConfigServiceClientInterface) {
         self.appConfigServiceClient = appConfigServiceClient
@@ -39,6 +43,15 @@ public final class AppConfigService: AppConfigServiceInterface {
             }
         )
         updateSearch(urlString: config.searchApiUrl)
+        updateChatPollInterval(config.chatPollIntervalSeconds)
+    }
+
+    private func updateChatPollInterval(_ interval: Int?) {
+        guard let pollInterval = interval,
+              pollInterval > 0 else {
+            return
+        }
+        chatPollIntervalSeconds = TimeInterval((pollInterval))
     }
 
     private func updateSearch(urlString: String?) {

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Arrangers/Model/Config+Arrangers.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Arrangers/Model/Config+Arrangers.swift
@@ -13,7 +13,8 @@ extension Config {
                         releaseFlags: [String: Bool] = [:],
                         lastUpdated: String = "test",
                         searchApiUrl: String? = nil,
-                        authenticationIssuerBaseUrl: String = "https://test.com") -> Config {
+                        authenticationIssuerBaseUrl: String = "https://test.com",
+                        chatPollIntervalSeconds: Int? = 3) -> Config {
         .init(
             available: available,
             minimumVersion: minimumVersion,
@@ -21,7 +22,8 @@ extension Config {
             releaseFlags: releaseFlags,
             lastUpdated: lastUpdated,
             searchApiUrl: searchApiUrl,
-            authenticationIssuerBaseUrl: authenticationIssuerBaseUrl
+            authenticationIssuerBaseUrl: authenticationIssuerBaseUrl,
+            chatPollIntervalSeconds: chatPollIntervalSeconds
         )
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/AppConfigServiceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/AppConfigServiceTests.swift
@@ -29,6 +29,45 @@ struct AppConfigServiceTests {
     }
 
     @Test
+    func fetchAppConfig_updatesChatPollingInterval() async {
+        let configResult = Config.arrange(chatPollIntervalSeconds: 10).toResult()
+        _ = await withCheckedContinuation { continuation in
+            sut.fetchAppConfig(completion: continuation.resume)
+            mockAppConfigServiceClient._receivedFetchAppConfigCompletion?(
+                configResult
+            )
+        }
+
+        #expect(sut.chatPollIntervalSeconds == 10.0)
+    }
+
+    @Test
+    func fetchAppConfig_missingPolligInterval_setsDefaultValue() async {
+        let configResult = Config.arrange(chatPollIntervalSeconds: nil).toResult()
+        _ = await withCheckedContinuation { continuation in
+            sut.fetchAppConfig(completion: continuation.resume)
+            mockAppConfigServiceClient._receivedFetchAppConfigCompletion?(
+                configResult
+            )
+        }
+
+        #expect(sut.chatPollIntervalSeconds == 3.0)
+    }
+
+    @Test
+    func fetchAppConfig_zeroPolligInterval_setsDefaultValue() async {
+        let configResult = Config.arrange(chatPollIntervalSeconds: 0).toResult()
+        _ = await withCheckedContinuation { continuation in
+            sut.fetchAppConfig(completion: continuation.resume)
+            mockAppConfigServiceClient._receivedFetchAppConfigCompletion?(
+                configResult
+            )
+        }
+
+        #expect(sut.chatPollIntervalSeconds == 3.0)
+    }
+
+    @Test
     func isFeatureEnabled_whenFeatureFlagIsSetToAvailable_returnsTrue() {
         let result = Config.arrange(releaseFlags: ["search": true]).toResult()
         sut.fetchAppConfig(completion: { _ in })

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/ChatServiceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/ChatServiceTests.swift
@@ -14,6 +14,7 @@ final class ChatServiceTests {
         mockChatServiceClient = MockChatServiceClient()
         mockChatRepository = MockChatRespository()
         mockConfigService = MockAppConfigService()
+        mockConfigService._stubbedChatPollIntervalSeconds = 0.2
     }
 
     deinit {
@@ -27,8 +28,7 @@ final class ChatServiceTests {
         let sut = ChatService(
             serviceClient: mockChatServiceClient,
             chatRepository: mockChatRepository,
-            configService: mockConfigService,
-            retryInterval: 0.2
+            configService: mockConfigService
         )
 
         mockChatServiceClient._stubbedAskQuestionResult = .success(.pendingQuestion)
@@ -53,8 +53,7 @@ final class ChatServiceTests {
         let sut = ChatService(
             serviceClient: mockChatServiceClient,
             chatRepository: mockChatRepository,
-            configService: mockConfigService,
-            retryInterval: 0.2
+            configService: mockConfigService
         )
 
         mockChatServiceClient._stubbedAskQuestionResult = .success(.pendingQuestion)
@@ -77,8 +76,7 @@ final class ChatServiceTests {
         let sut = ChatService(
             serviceClient: mockChatServiceClient,
             chatRepository: mockChatRepository,
-            configService: mockConfigService,
-            retryInterval: 0.2
+            configService: mockConfigService
         )
         
         mockChatServiceClient._stubbedAskQuestionResult = .failure(ChatError.networkUnavailable)
@@ -101,8 +99,7 @@ final class ChatServiceTests {
         let sut = ChatService(
             serviceClient: mockChatServiceClient,
             chatRepository: mockChatRepository,
-            configService: mockConfigService,
-            retryInterval: 0.2
+            configService: mockConfigService
         )
 
         mockChatServiceClient._stubbedFetchAnswerResults = [
@@ -131,8 +128,7 @@ final class ChatServiceTests {
         let sut = ChatService(
             serviceClient: mockChatServiceClient,
             chatRepository: mockChatRepository,
-            configService: mockConfigService,
-            retryInterval: 0.2
+            configService: mockConfigService
         )
 
         mockChatServiceClient._stubbedFetchAnswerResults = [
@@ -158,9 +154,7 @@ final class ChatServiceTests {
         let sut = ChatService(
             serviceClient: mockChatServiceClient,
             chatRepository: mockChatRepository,
-            configService: mockConfigService,
-            maxRetryCount: 3,
-            retryInterval: 0.2
+            configService: mockConfigService
         )
 
         mockChatServiceClient._stubbedFetchHistoryResult = .success(.history)
@@ -184,9 +178,7 @@ final class ChatServiceTests {
         let sut = ChatService(
             serviceClient: mockChatServiceClient,
             chatRepository: mockChatRepository,
-            configService: mockConfigService,
-            maxRetryCount: 1,
-            retryInterval: 0.2
+            configService: mockConfigService
         )
 
         mockChatServiceClient._stubbedFetchHistoryResult = .failure(ChatError.apiUnavailable)
@@ -211,9 +203,7 @@ final class ChatServiceTests {
         let sut = ChatService(
             serviceClient: mockChatServiceClient,
             chatRepository: mockChatRepository,
-            configService: mockConfigService,
-            maxRetryCount: 1,
-            retryInterval: 0.2
+            configService: mockConfigService
         )
 
         sut.clearHistory()
@@ -225,9 +215,7 @@ final class ChatServiceTests {
         let sut = ChatService(
             serviceClient: mockChatServiceClient,
             chatRepository: mockChatRepository,
-            configService: mockConfigService,
-            maxRetryCount: 1,
-            retryInterval: 0.2
+            configService: mockConfigService
         )
         mockConfigService.features = []
 
@@ -239,9 +227,7 @@ final class ChatServiceTests {
         let sut = ChatService(
             serviceClient: mockChatServiceClient,
             chatRepository: mockChatRepository,
-            configService: mockConfigService,
-            maxRetryCount: 1,
-            retryInterval: 0.2
+            configService: mockConfigService
         )
         mockConfigService.features = [.chat]
 

--- a/Tests/govuk_ios/shared/Mocks/Services/MockAppConfigService.swift
+++ b/Tests/govuk_ios/shared/Mocks/Services/MockAppConfigService.swift
@@ -3,6 +3,11 @@ import Foundation
 @testable import govuk_ios
 
 class MockAppConfigService: AppConfigServiceInterface {
+    var _stubbedChatPollIntervalSeconds: TimeInterval = 3.0
+    var chatPollIntervalSeconds: TimeInterval {
+        _stubbedChatPollIntervalSeconds
+    }
+
     var isAppAvailable: Bool = false
 
     var isAppForcedUpdate: Bool = false


### PR DESCRIPTION
Read the chat polling interval from the AppConfig
Polling interval is now a property on the AppConfigService
If the value is missing or zero, default to 3 seconds.
Remove maxRetryCount as it is no longer used.