### PR TITLE
govukapp 2285 make clear chat conditional

### DIFF
--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -8,7 +8,7 @@ class ChatViewModel: ObservableObject {
     let maxCharacters = 300
     private let openURLAction: (URL) -> Void
     private let handleError: (ChatError) -> Void
-    private var requestInFlight: Bool = false
+    private(set) var requestInFlight: Bool = false
 
     @Published var cellModels: [ChatCellViewModel] = []
     @Published var latestQuestion: String = ""

--- a/Production/govuk_ios/Views/Chat/ChatActionView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatActionView.swift
@@ -102,6 +102,7 @@ struct ChatActionView: View {
                         Label(String.chat.localized("clearMenuTitle"), systemImage: "trash")
                     }
                 )
+                .disabled(viewModel.requestInFlight)
             }
             Button(
                 action: { viewModel.openAboutURL() },


### PR DESCRIPTION
Hide clear chat menu option if no conversation exists
Disable clear chat option if a request is pending, as clearing while waiting on an answer gives unpredictable results