### PR TITLE
[GOVUKAPP-2273] Feature/add chat analytics

### DIFF
--- a/GovUK.xcodeproj/project.pbxproj
+++ b/GovUK.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		162DD75B2C247ACE00FA482D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 162DD75A2C247ACE00FA482D /* GoogleService-Info.plist */; };
 		162EC84D2DDB54E3000A7224 /* LocalAuthentication.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 162EC84C2DDB54E3000A7224 /* LocalAuthentication.xcstrings */; };
 		1631DE992C2B0D020050CB9D /* DeviceInformationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1631DE982C2B0D020050CB9D /* DeviceInformationProvider.swift */; };
+		1633812A2E533A9300AC1CED /* AppEvent+Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163381292E533A8C00AC1CED /* AppEvent+Chat.swift */; };
 		164091FC2DA41B3000E3BE99 /* AuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164091FB2DA41B2700E3BE99 /* AuthenticationService.swift */; };
 		164091FE2DA41C1000E3BE99 /* AuthenticationServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164091FD2DA41C0700E3BE99 /* AuthenticationServiceClient.swift */; };
 		164150AF2DE5DB6D00798DF3 /* WelcomeOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164150AE2DE5DB6800798DF3 /* WelcomeOnboardingViewModel.swift */; };
@@ -418,6 +419,7 @@
 		162DD75A2C247ACE00FA482D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		162EC84C2DDB54E3000A7224 /* LocalAuthentication.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = LocalAuthentication.xcstrings; sourceTree = "<group>"; };
 		1631DE982C2B0D020050CB9D /* DeviceInformationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInformationProvider.swift; sourceTree = "<group>"; };
+		163381292E533A8C00AC1CED /* AppEvent+Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppEvent+Chat.swift"; sourceTree = "<group>"; };
 		164091FB2DA41B2700E3BE99 /* AuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationService.swift; sourceTree = "<group>"; };
 		164091FD2DA41C0700E3BE99 /* AuthenticationServiceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceClient.swift; sourceTree = "<group>"; };
 		164150AE2DE5DB6800798DF3 /* WelcomeOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeOnboardingViewModel.swift; sourceTree = "<group>"; };
@@ -1674,6 +1676,7 @@
 		5DE970552C297CF3009D66C4 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				163381292E533A8C00AC1CED /* AppEvent+Chat.swift */,
 				5DE970562C297CFE009D66C4 /* AppEvent+Convenience.swift */,
 				D0F5FF7D2D64D22400C3BF51 /* AppEvent+ECommerce.swift */,
 				5D66D1832CBFC12400006723 /* AppEvent+Function.swift */,
@@ -2357,6 +2360,7 @@
 				5D79AEC02C32B9180061F344 /* AnimationView.swift in Sources */,
 				4E00EEF12CCB04FF007B61E8 /* TopicOnboardingCard.swift in Sources */,
 				5D9E67C82C5A2E1700DB7877 /* DividerView.swift in Sources */,
+				1633812A2E533A9300AC1CED /* AppEvent+Chat.swift in Sources */,
 				5DD4C7972D9547D600459FB5 /* AppEvent+RecentActivity.swift in Sources */,
 				5D66D1862CBFC13100006723 /* AppEvent+Navigation.swift in Sources */,
 				D0D655E82D26A79000571841 /* UIApplication+URLOpener.swift in Sources */,

--- a/Production/govuk_ios/Extensions/Analytics/AppEvent+Chat.swift
+++ b/Production/govuk_ios/Extensions/Analytics/AppEvent+Chat.swift
@@ -22,4 +22,16 @@ extension AppEvent {
             ]
         )
     }
+
+    static func chatLinkNavigation(text: String,
+                                   url: String) -> AppEvent {
+        navigation(
+            text: text,
+            type: "ChatMarkdownLink",
+            external: true,
+            additionalParams: [
+                "url": url
+            ]
+        )
+    }
 }

--- a/Production/govuk_ios/Extensions/Analytics/AppEvent+Chat.swift
+++ b/Production/govuk_ios/Extensions/Analytics/AppEvent+Chat.swift
@@ -10,4 +10,16 @@ extension AppEvent {
             action: action
         )
     }
+
+    static func chatAskQuestion(text: String,
+                                type: String = "typed") -> AppEvent {
+        .init(
+            name: "Chat",
+            params: [
+                "text": text,
+                "type": type,
+                "action": "Ask Question"
+            ]
+        )
+    }
 }

--- a/Production/govuk_ios/Extensions/Analytics/AppEvent+Chat.swift
+++ b/Production/govuk_ios/Extensions/Analytics/AppEvent+Chat.swift
@@ -1,0 +1,13 @@
+import Foundation
+import GOVKit
+
+extension AppEvent {
+    static func chatActionButtonFunction(text: String,
+                                         action: String) -> AppEvent {
+        buttonFunction(
+            text: text,
+            section: "Action Menu",
+            action: action
+        )
+    }
+}

--- a/Production/govuk_ios/ViewModels/Chat/ChatCellViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatCellViewModel.swift
@@ -112,6 +112,17 @@ struct ChatCellViewModel {
         )
         analyticsService?.track(event: event)
     }
+
+    func trackSourceListToggle(isExpanded: Bool) {
+        guard isExpanded else { return }
+
+        let event = AppEvent.buttonFunction(
+            text: "Expanded",
+            section: "Source Links",
+            action: "Source Links Expanded"
+        )
+        analyticsService?.track(event: event)
+    }
 }
 
 extension ChatCellViewModel {

--- a/Production/govuk_ios/ViewModels/Chat/ChatCellViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatCellViewModel.swift
@@ -1,6 +1,12 @@
 import Foundation
 import SwiftUI
 import UIComponents
+import GOVKit
+
+enum ChatLinkType: String {
+    case sourceLink = "Source Link"
+    case responseLink = "Response Link"
+}
 
 enum ChatCellType {
     case question
@@ -16,19 +22,22 @@ struct ChatCellViewModel {
     let type: ChatCellType
     let sources: [Source]
     let openURLAction: ((URL) -> Void)?
+    let analyticsService: AnalyticsServiceInterface?
 
     init(title: String? = nil,
          message: String,
          id: String,
          type: ChatCellType,
          sources: [Source] = [],
-         openURLAction: ((URL) -> Void)? = nil) {
+         openURLAction: ((URL) -> Void)? = nil,
+         analyticsService: AnalyticsServiceInterface? = nil) {
         self.title = title
         self.message = message
         self.id = id
         self.type = type
         self.sources = sources
         self.openURLAction = openURLAction
+        self.analyticsService = analyticsService
     }
 
     init(question: PendingQuestion) {
@@ -38,13 +47,17 @@ struct ChatCellViewModel {
     }
 
     init(answer: Answer,
-         openURLAction: ((URL) -> Void)? ) {
-        self.init(title: String.chat.localized("answerTitle"),
-                  message: answer.message ?? "",
-                  id: answer.id ?? UUID().uuidString,
-                  type: .answer,
-                  sources: answer.sources ?? [],
-                  openURLAction: openURLAction)
+         openURLAction: @escaping (URL) -> Void,
+         analyticsService: AnalyticsServiceInterface) {
+        self.init(
+            title: String.chat.localized("answerTitle"),
+            message: answer.message ?? "",
+            id: answer.id ?? UUID().uuidString,
+            type: .answer,
+            sources: answer.sources ?? [],
+            openURLAction: openURLAction,
+            analyticsService: analyticsService
+        )
     }
 
     init(answeredQuestion: AnsweredQuestion) {
@@ -89,6 +102,15 @@ struct ChatCellViewModel {
 
     var questionWidth: CGFloat {
         UIScreen.main.bounds.width * 0.2
+    }
+
+    func openURL(url: URL, type: ChatLinkType) {
+        openURLAction?(url)
+        let event = AppEvent.chatLinkNavigation(
+            text: "\(type.rawValue) Opened",
+            url: url.absoluteString
+        )
+        analyticsService?.track(event: event)
     }
 }
 

--- a/Production/govuk_ios/ViewModels/Chat/ChatConsentOnboardingViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatConsentOnboardingViewModel.swift
@@ -20,10 +20,11 @@ class ChatConsentOnboardingViewModel {
 
     var buttonViewModel: GOVUKButton.ButtonViewModel {
         return .init(
-            localisedTitle: String.chat.localized("onboardingConsentButtonTitle"),
+            localisedTitle: buttonTitle,
             action: { [weak self] in
                 self?.chatService.setChatOnboarded()
                 self?.completionAction()
+                self?.trackCompletionAction()
             }
         )
     }
@@ -32,8 +33,33 @@ class ChatConsentOnboardingViewModel {
         .cancel(target: self, action: #selector(cancelOnboarding))
     }
 
+    private var buttonTitle: String {
+        return String.chat.localized("onboardingConsentButtonTitle")
+    }
+
     @objc
     func cancelOnboarding() {
         cancelOnboardingAction()
+        trackCancelAction()
+    }
+
+    func trackScreen(screen: TrackableScreen) {
+        analyticsService.track(screen: screen)
+    }
+
+    private func trackCancelAction() {
+        let event = AppEvent.buttonNavigation(
+            text: String.common.localized("cancel"),
+            external: false
+        )
+        analyticsService.track(event: event)
+    }
+
+    private func trackCompletionAction() {
+        let event = AppEvent.buttonNavigation(
+            text: buttonTitle,
+            external: false
+        )
+        analyticsService.track(event: event)
     }
 }

--- a/Production/govuk_ios/ViewModels/Chat/ChatInfoOnboardingViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatInfoOnboardingViewModel.swift
@@ -3,7 +3,7 @@ import GOVKit
 import UIComponents
 
 class ChatInfoOnboardingViewModel: InfoViewModelInterface {
-    private let analyticsService: AnalyticsServiceInterface
+    var analyticsService: AnalyticsServiceInterface?
     private let completionAction: () -> Void
     private let cancelOnboardingAction: () -> Void
 
@@ -37,6 +37,7 @@ class ChatInfoOnboardingViewModel: InfoViewModelInterface {
             localisedTitle: localTitle,
             action: { [weak self] in
                 self?.completionAction()
+                self?.trackCompletionAction()
             }
         )
     }
@@ -68,11 +69,28 @@ class ChatInfoOnboardingViewModel: InfoViewModelInterface {
     }
 
     var trackingName: String {
-        "First chat onboarding"
+        "Chat Onboarding Screen One"
     }
 
     @objc
     func cancelOnboarding() {
         cancelOnboardingAction()
+        trackCancelAction()
+    }
+
+    private func trackCancelAction() {
+        let event = AppEvent.buttonNavigation(
+            text: String.common.localized("cancel"),
+            external: false
+        )
+        analyticsService?.track(event: event)
+    }
+
+    private func trackCompletionAction() {
+        let event = AppEvent.buttonNavigation(
+            text: buttonTitle,
+            external: false
+        )
+        analyticsService?.track(event: event)
     }
 }

--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -69,18 +69,20 @@ class ChatViewModel: ObservableObject {
         requestInFlight = true
         cellModels.append(.gettingAnswer)
         chatService.pollForAnswer(question) { [weak self] result in
-            self?.cellModels.removeLast()
-            self?.requestInFlight = false
+            guard let self else { return }
+            cellModels.removeLast()
+            requestInFlight = false
             switch result {
             case .success(let answer):
                 let cellModel = ChatCellViewModel(
                     answer: answer,
-                    openURLAction: self?.openURLAction
+                    openURLAction: openURLAction,
+                    analyticsService: analyticsService
                 )
-                self?.scrollToTop = true
-                self?.cellModels.append(cellModel)
+                scrollToTop = true
+                cellModels.append(cellModel)
             case .failure(let error):
-                self?.handleError(error)
+                handleError(error)
             }
         }
     }
@@ -151,7 +153,8 @@ class ChatViewModel: ObservableObject {
             cellModels.append(question)
             let answer = ChatCellViewModel(
                 answer: answeredQuestion.answer,
-                openURLAction: openURLAction
+                openURLAction: openURLAction,
+                analyticsService: analyticsService
             )
             cellModels.append(answer)
         }

--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -179,4 +179,44 @@ class ChatViewModel: ObservableObject {
     func trackScreen(screen: TrackableScreen) {
         analyticsService.track(screen: screen)
     }
+
+    func trackMenuTap() {
+        let event = AppEvent.chatActionButtonFunction(
+            text: String.chat.localized("moreOptionsAccessibilityLabel"),
+            action: "Action Menu Opened"
+        )
+        analyticsService.track(event: event)
+    }
+
+    func trackMenuAboutTap() {
+        let event = AppEvent.buttonNavigation(
+            text: String.chat.localized("aboutMenuTitle"),
+            external: true
+        )
+        analyticsService.track(event: event)
+    }
+
+    func trackMenuClearChatTap() {
+        let event = AppEvent.chatActionButtonFunction(
+            text: String.chat.localized("clearMenuTitle"),
+            action: "Clear Chat Opened"
+        )
+        analyticsService.track(event: event)
+    }
+
+    func trackMenuClearChatConfirmTap() {
+        let event = AppEvent.chatActionButtonFunction(
+            text: String.chat.localized("clearAlertConfirmTitle"),
+            action: "Clear Chat Yes Tapped"
+        )
+        analyticsService.track(event: event)
+    }
+
+    func trackMenuClearChatDenyTap() {
+        let event = AppEvent.chatActionButtonFunction(
+            text: String.chat.localized("clearAlertDenyTitle"),
+            action: "Clear Chat No Tapped"
+        )
+        analyticsService.track(event: event)
+    }
 }

--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -36,6 +36,7 @@ class ChatViewModel: ObservableObject {
             completion?(false)
             return
         }
+        trackAskQuestionSubmission()
         errorText = nil
         cellModels.append(.loadingQuestion)
         scrollToBottom = true
@@ -216,6 +217,13 @@ class ChatViewModel: ObservableObject {
         let event = AppEvent.chatActionButtonFunction(
             text: String.chat.localized("clearAlertDenyTitle"),
             action: "Clear Chat No Tapped"
+        )
+        analyticsService.track(event: event)
+    }
+
+    private func trackAskQuestionSubmission() {
+        let event = AppEvent.chatAskQuestion(
+            text: latestQuestion
         )
         analyticsService.track(event: event)
     }

--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -177,6 +177,7 @@ class ChatViewModel: ObservableObject {
     }
 
     func openAboutURL() {
+        trackMenuAboutTap()
         openURLAction(Constants.API.govukBaseUrl)
     }
 
@@ -184,26 +185,10 @@ class ChatViewModel: ObservableObject {
         analyticsService.track(screen: screen)
     }
 
-    func trackMenuTap() {
-        let event = AppEvent.chatActionButtonFunction(
-            text: String.chat.localized("moreOptionsAccessibilityLabel"),
-            action: "Action Menu Opened"
-        )
-        analyticsService.track(event: event)
-    }
-
-    func trackMenuAboutTap() {
-        let event = AppEvent.buttonNavigation(
-            text: String.chat.localized("aboutMenuTitle"),
-            external: true
-        )
-        analyticsService.track(event: event)
-    }
-
     func trackMenuClearChatTap() {
         let event = AppEvent.chatActionButtonFunction(
             text: String.chat.localized("clearMenuTitle"),
-            action: "Clear Chat Opened"
+            action: "Clear Chat Tapped"
         )
         analyticsService.track(event: event)
     }
@@ -220,6 +205,14 @@ class ChatViewModel: ObservableObject {
         let event = AppEvent.chatActionButtonFunction(
             text: String.chat.localized("clearAlertDenyTitle"),
             action: "Clear Chat No Tapped"
+        )
+        analyticsService.track(event: event)
+    }
+
+    private func trackMenuAboutTap() {
+        let event = AppEvent.buttonNavigation(
+            text: String.chat.localized("aboutMenuTitle"),
+            external: true
         )
         analyticsService.track(event: event)
     }

--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -175,4 +175,8 @@ class ChatViewModel: ObservableObject {
     func openAboutURL() {
         openURLAction(Constants.API.govukBaseUrl)
     }
+
+    func trackScreen(screen: TrackableScreen) {
+        analyticsService.track(screen: screen)
+    }
 }

--- a/Production/govuk_ios/Views/Chat/ChatActionView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatActionView.swift
@@ -101,15 +101,15 @@ struct ChatActionView: View {
             if viewModel.currentConversationExists {
                 Button(
                     role: .destructive,
-                    action: { showClearChatAlert = true },
+                    action: {
+                        viewModel.trackMenuClearChatTap()
+                        showClearChatAlert = true
+                    },
                     label: {
                         Label(String.chat.localized("clearMenuTitle"), systemImage: "trash")
                     }
                 )
                 .disabled(viewModel.requestInFlight)
-                .onTapGesture {
-                    viewModel.trackMenuAboutTap()
-                }
             }
             Button(
                 action: { viewModel.openAboutURL() },
@@ -119,9 +119,6 @@ struct ChatActionView: View {
                         .accessibilityHint(String.common.localized("openWebLinkHint"))
                 }
             )
-            .onTapGesture {
-                viewModel.trackMenuClearChatTap()
-            }
         } label: {
             Image(systemName: "ellipsis")
                 .font(.system(size: 18, weight: .bold))
@@ -138,9 +135,6 @@ struct ChatActionView: View {
                                 )
                         )
                 )
-                .onTapGesture {
-                    viewModel.trackMenuTap()
-                }
         }
         .accessibilityLabel(String.chat.localized("moreOptionsAccessibilityLabel"))
         .accessibilitySortPriority(0)

--- a/Production/govuk_ios/Views/Chat/ChatActionView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatActionView.swift
@@ -47,10 +47,14 @@ struct ChatActionView: View {
                     Text(String.chat.localized("clearAlertConfirmTitle")),
                     action: {
                         viewModel.newChat()
+                        viewModel.trackMenuClearChatConfirmTap()
                     }
                 ),
                 secondaryButton: .cancel(
-                    Text(String.chat.localized("clearAlertDenyTitle"))
+                    Text(String.chat.localized("clearAlertDenyTitle")),
+                    action: {
+                        viewModel.trackMenuClearChatDenyTap()
+                    }
                 )
             )
         }
@@ -103,6 +107,9 @@ struct ChatActionView: View {
                     }
                 )
                 .disabled(viewModel.requestInFlight)
+                .onTapGesture {
+                    viewModel.trackMenuAboutTap()
+                }
             }
             Button(
                 action: { viewModel.openAboutURL() },
@@ -112,6 +119,9 @@ struct ChatActionView: View {
                         .accessibilityHint(String.common.localized("openWebLinkHint"))
                 }
             )
+            .onTapGesture {
+                viewModel.trackMenuClearChatTap()
+            }
         } label: {
             Image(systemName: "ellipsis")
                 .font(.system(size: 18, weight: .bold))
@@ -128,6 +138,9 @@ struct ChatActionView: View {
                                 )
                         )
                 )
+                .onTapGesture {
+                    viewModel.trackMenuTap()
+                }
         }
         .accessibilityLabel(String.chat.localized("moreOptionsAccessibilityLabel"))
         .accessibilitySortPriority(0)

--- a/Production/govuk_ios/Views/Chat/ChatCellView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatCellView.swift
@@ -158,7 +158,7 @@ struct ChatCellView: View {
             })
             .fixedSize(horizontal: false, vertical: true)
             .environment(\.openURL, OpenURLAction { url in
-                viewModel.openURLAction?(url)
+                viewModel.openURL(url: url, type: .responseLink)
                 return .handled
             })
     }
@@ -172,7 +172,7 @@ struct ChatCellView: View {
             .accessibilityHint(String.common.localized("openWebLinkHint"))
             .accessibilityRemoveTraits(.isButton)
             .environment(\.openURL, OpenURLAction { url in
-                viewModel.openURLAction?(url)
+                viewModel.openURL(url: url, type: .sourceLink)
                 return .handled
             })
             Divider()

--- a/Production/govuk_ios/Views/Chat/ChatCellView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatCellView.swift
@@ -135,8 +135,11 @@ struct ChatCellView: View {
                     .foregroundColor(Color(UIColor.govUK.text.primary))
             }
         }
-        .disclosureGroupStyle(ChatDisclosure())
-        .padding(.top, 8)
+        .disclosureGroupStyle(
+            ChatDisclosure(trackToggle: { isExpanded in
+                viewModel.trackSourceListToggle(isExpanded: isExpanded)
+            })
+        ).padding(.top, 8)
     }
 
     private var warningView: some View {
@@ -193,6 +196,8 @@ struct ChatCellView: View {
 }
 
 struct ChatDisclosure: DisclosureGroupStyle {
+    var trackToggle: (Bool) -> Void
+
     func makeBody(configuration: Configuration) -> some View {
         VStack {
             disclosureButtonView(configuration: configuration)
@@ -206,6 +211,7 @@ struct ChatDisclosure: DisclosureGroupStyle {
         Button {
             withAnimation {
                 configuration.isExpanded.toggle()
+                trackToggle(configuration.isExpanded)
             }
         } label: {
             HStack(alignment: .firstTextBaseline) {

--- a/Production/govuk_ios/Views/Chat/ChatConsentOnboardingView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatConsentOnboardingView.swift
@@ -27,6 +27,9 @@ struct ChatConsentOnboardingView: View {
             .padding(16)
             .ignoresSafeArea()
         }
+        .onAppear {
+            viewModel.trackScreen(screen: self)
+        }
     }
 
     private func consentScrollView(geometry: GeometryProxy) -> some View {
@@ -97,10 +100,10 @@ struct ChatConsentOnboardingView: View {
 
 extension ChatConsentOnboardingView: TrackableScreen {
     var trackingName: String {
-        "Second chat onboarding"
+        "Chat Onboarding Screen Two"
     }
 
     var trackingTitle: String? {
-        "Double-check the answers"
+        String.chat.localized("onboardingConsentTitle")
     }
 }

--- a/Production/govuk_ios/Views/Chat/ChatView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GOVKit
 
 struct ChatView: View {
     @Environment(\.verticalSizeClass) var verticalSizeClass
@@ -35,6 +36,7 @@ struct ChatView: View {
         }
         .onAppear {
             viewModel.loadHistory()
+            viewModel.trackScreen(screen: self)
             withAnimation(
                 .easeIn(
                     duration: viewModel.currentConversationExists ? 0.0 : introDuration * 4
@@ -168,5 +170,15 @@ struct ChatView: View {
             startPoint: .top,
             endPoint: .bottom
         )
+    }
+}
+
+extension ChatView: TrackableScreen {
+    var trackingName: String {
+        "Chat Screen"
+    }
+
+    var trackingTitle: String? {
+        "Chat Screen"
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatCellViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatCellViewModelTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+import GOVKit
+
+@testable import govuk_ios
+@testable import GOVKitTestUtilities
+
+@Suite
+struct ChatCellViewModelTests {
+    @Test
+    func openURL_responseLink_opensURLAndTracksEvent() async {
+        await confirmation() { confirmation in
+            let mockAnalyticsService = MockAnalyticsService()
+            let sut = ChatCellViewModel(
+                message: "test",
+                id: UUID().uuidString,
+                type: .answer,
+                openURLAction: { _ in confirmation() },
+                analyticsService: mockAnalyticsService
+            )
+
+            sut.openURL(
+                url: URL(string: "https://wwww.gov.uk")!,
+                type: .responseLink
+            )
+            #expect(mockAnalyticsService._trackedEvents.count == 1)
+            #expect(
+                mockAnalyticsService
+                    ._trackedEvents.first?.params?["text"] as? String == "Response Link Opened"
+            )
+        }
+    }
+
+    @Test
+    func openURL_sourceLink_opensURLAndTracksEvent() async {
+        await confirmation() { confirmation in
+            let mockAnalyticsService = MockAnalyticsService()
+            let sut = ChatCellViewModel(
+                message: "test",
+                id: UUID().uuidString,
+                type: .answer,
+                openURLAction: { _ in confirmation() },
+                analyticsService: mockAnalyticsService
+            )
+
+            sut.openURL(
+                url: URL(string: "https://wwww.gov.uk")!,
+                type: .sourceLink
+            )
+            #expect(mockAnalyticsService._trackedEvents.count == 1)
+            #expect(
+                mockAnalyticsService
+                    ._trackedEvents.first?.params?["text"] as? String == "Source Link Opened"
+            )
+        }
+    }
+}

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatCellViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatCellViewModelTests.swift
@@ -54,4 +54,38 @@ struct ChatCellViewModelTests {
             )
         }
     }
+
+    @Test
+    func trackSourceListToggle_expanded_tracksEvent() async {
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut = ChatCellViewModel(
+            message: "test",
+            id: UUID().uuidString,
+            type: .answer,
+            openURLAction: { _ in },
+            analyticsService: mockAnalyticsService
+        )
+
+        sut.trackSourceListToggle(isExpanded: true)
+        #expect(mockAnalyticsService._trackedEvents.count == 1)
+        #expect(
+            mockAnalyticsService
+                ._trackedEvents.first?.params?["text"] as? String == "Expanded"
+        )
+    }
+
+    @Test
+    func trackSourceListToggle_hidden_doesntTrackEvent() async {
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut = ChatCellViewModel(
+            message: "test",
+            id: UUID().uuidString,
+            type: .answer,
+            openURLAction: { _ in },
+            analyticsService: mockAnalyticsService
+        )
+
+        sut.trackSourceListToggle(isExpanded: false)
+        #expect(mockAnalyticsService._trackedEvents.count == 0)
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatInfoOnboardingViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatInfoOnboardingViewModelTests.swift
@@ -47,6 +47,36 @@ struct ChatInfoOnboardingViewModelTests {
             cancelOnboardingAction: { }
         )
 
-        #expect(sut.trackingName == "First chat onboarding")
+        #expect(sut.trackingName == "Chat Onboarding Screen One")
+    }
+
+    @Test
+    func buttonViewModel_action_tracksEvent() {
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut = ChatInfoOnboardingViewModel(
+            analyticsService: mockAnalyticsService,
+            completionAction: { },
+            cancelOnboardingAction: { }
+        )
+        sut.buttonViewModel.action()
+
+        #expect(mockAnalyticsService._trackedEvents.count == 1)
+        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "Continue")
+    }
+
+    @Test
+    func cancelOnboarding_callsActionAndTracksEvent() async {
+        await confirmation() { confirmation in
+            let mockAnalyticsService = MockAnalyticsService()
+            let sut = ChatInfoOnboardingViewModel(
+                analyticsService: mockAnalyticsService,
+                completionAction: { },
+                cancelOnboardingAction: { confirmation() }
+            )
+            sut.cancelOnboarding()
+
+            #expect(mockAnalyticsService._trackedEvents.count == 1)
+            #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "Cancel")
+        }
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
@@ -276,33 +276,20 @@ struct ChatViewModelTests {
     }
 
     @Test
-    func trackMenuTap_tracksEvent() {
-        let mockAnalyticsService = MockAnalyticsService()
-        let sut = ChatViewModel(
-            chatService: MockChatService(),
-            analyticsService: mockAnalyticsService,
-            openURLAction: { _ in },
-            handleError: { _ in }
-        )
+    func openAboutURL_opensURLAndtracksEvent() async {
+        await confirmation() { confirmation in
+            let mockAnalyticsService = MockAnalyticsService()
+            let sut = ChatViewModel(
+                chatService: MockChatService(),
+                analyticsService: mockAnalyticsService,
+                openURLAction: { _ in confirmation() },
+                handleError: { _ in }
+            )
 
-        sut.trackMenuTap()
-        #expect(mockAnalyticsService._trackedEvents.count == 1)
-        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "More options")
-    }
-
-    @Test
-    func trackMenuAboutTap_tracksEvent() {
-        let mockAnalyticsService = MockAnalyticsService()
-        let sut = ChatViewModel(
-            chatService: MockChatService(),
-            analyticsService: mockAnalyticsService,
-            openURLAction: { _ in },
-            handleError: { _ in }
-        )
-
-        sut.trackMenuAboutTap()
-        #expect(mockAnalyticsService._trackedEvents.count == 1)
-        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "About")
+            sut.openAboutURL()
+            #expect(mockAnalyticsService._trackedEvents.count == 1)
+            #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "About")
+        }
     }
 
     @Test

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
@@ -252,4 +252,79 @@ struct ChatViewModelTests {
         sut.newChat()
         #expect(mockChatService._clearHistoryCalled)
     }
+
+    @Test
+    func trackMenuTap_tracksEvent() {
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut = ChatViewModel(
+            chatService: MockChatService(),
+            analyticsService: mockAnalyticsService,
+            openURLAction: { _ in },
+            handleError: { _ in }
+        )
+
+        sut.trackMenuTap()
+        #expect(mockAnalyticsService._trackedEvents.count == 1)
+        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "More options")
+    }
+
+    @Test
+    func trackMenuAboutTap_tracksEvent() {
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut = ChatViewModel(
+            chatService: MockChatService(),
+            analyticsService: mockAnalyticsService,
+            openURLAction: { _ in },
+            handleError: { _ in }
+        )
+
+        sut.trackMenuAboutTap()
+        #expect(mockAnalyticsService._trackedEvents.count == 1)
+        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "About")
+    }
+
+    @Test
+    func trackMenuClearChatTap_tracksEvent() {
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut = ChatViewModel(
+            chatService: MockChatService(),
+            analyticsService: mockAnalyticsService,
+            openURLAction: { _ in },
+            handleError: { _ in }
+        )
+
+        sut.trackMenuClearChatTap()
+        #expect(mockAnalyticsService._trackedEvents.count == 1)
+        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "Clear chat")
+    }
+
+    @Test
+    func trackMenuClearChatConfirmTap_tracksEvent() {
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut = ChatViewModel(
+            chatService: MockChatService(),
+            analyticsService: mockAnalyticsService,
+            openURLAction: { _ in },
+            handleError: { _ in }
+        )
+
+        sut.trackMenuClearChatConfirmTap()
+        #expect(mockAnalyticsService._trackedEvents.count == 1)
+        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "Yes, clear chat")
+    }
+
+    @Test
+    func trackMenuClearChatDenyTap_tracksEvent() {
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut = ChatViewModel(
+            chatService: MockChatService(),
+            analyticsService: mockAnalyticsService,
+            openURLAction: { _ in },
+            handleError: { _ in }
+        )
+
+        sut.trackMenuClearChatDenyTap()
+        #expect(mockAnalyticsService._trackedEvents.count == 1)
+        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "No, not now")
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
@@ -31,6 +31,26 @@ struct ChatViewModelTests {
     }
 
     @Test
+    func askQuestion_tracksEvent() async {
+        let mockChatService = MockChatService()
+        let mockAnalyticsService = MockAnalyticsService()
+        let sut = ChatViewModel(
+            chatService: mockChatService,
+            analyticsService: mockAnalyticsService,
+            openURLAction: { _ in },
+            handleError: { _ in }
+        )
+        sut.latestQuestion = "This is the question"
+        sut.askQuestion()
+
+        #expect(mockAnalyticsService._trackedEvents.count == 1)
+        #expect(
+            mockAnalyticsService
+                ._trackedEvents.first?.params?["text"] as? String == "This is the question"
+        )
+    }
+
+    @Test
     func askQuestion_answer_failure_callsHandleError() {
         let mockChatService = MockChatService()
         mockChatService._stubbedQuestionResult = .success(.pendingQuestion)
@@ -77,11 +97,12 @@ struct ChatViewModelTests {
     @Test
     func askQuestionWithPII_generatesErrorText() {
         let mockChatService = MockChatService()
+        let mockAnalyticsService = MockAnalyticsService()
         mockChatService._stubbedQuestionResult = .failure(ChatError.pageNotFound)
         var chatError: ChatError?
         let sut = ChatViewModel(
             chatService: mockChatService,
-            analyticsService: MockAnalyticsService(),
+            analyticsService: mockAnalyticsService,
             openURLAction: { _ in },
             handleError: { error in
                 chatError = error
@@ -96,6 +117,7 @@ struct ChatViewModelTests {
         #expect(chatError == nil)
         #expect(sut.errorText != nil)
         #expect(!sut.latestQuestion.isEmpty)
+        #expect(mockAnalyticsService._trackedEvents.count == 0)
     }
 
     @Test


### PR DESCRIPTION
Add analytics tracking for chat window and onboarding. 

Not tracking initial action menu tap as you can't easily attach a tap gesture to a Menu element in Swift UI.

More info in commits ->