### PR TITLE
[GOVUKAPP-2317] Tracks question answer response

### DIFF
--- a/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
+++ b/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
@@ -53,11 +53,12 @@ class SceneDelegate: UIResponder,
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
+        let appBackgrounded = "App Backgrounded"
         let appEvent = AppEvent.function(
-            text: "App Backgrounded",
+            text: appBackgrounded,
             type: "AppBackgrounded",
-            section: "App Backgrounded",
-            action: "App Backgrounded"
+            section: appBackgrounded,
+            action: appBackgrounded
         )
         analyticsService.track(event: appEvent)
     }

--- a/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
+++ b/Production/govuk_ios/SupportingFiles/SceneDelegate.swift
@@ -1,10 +1,12 @@
 import Foundation
 import UIKit
 import Factory
+import GOVKit
 
 class SceneDelegate: UIResponder,
                      UIWindowSceneDelegate {
     @Inject(\.inactivityService) private var inactivityService: InactivityServiceInterface
+    @Inject(\.analyticsService) private var analyticsService: AnalyticsServiceInterface
 
     var window: UIWindow?
 
@@ -48,5 +50,15 @@ class SceneDelegate: UIResponder,
 
     func sceneWillEnterForeground(_ scene: UIScene) {
         appCoordinator.start(url: nil)
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        let appEvent = AppEvent.function(
+            text: "App Backgrounded",
+            type: "AppBackgrounded",
+            section: "App Backgrounded",
+            action: "App Backgrounded"
+        )
+        analyticsService.track(event: appEvent)
     }
 }

--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -65,7 +65,7 @@ class ChatViewModel: ObservableObject {
         }
     }
 
-    func pollForAnswer(_ question: PendingQuestion) {
+    private func pollForAnswer(_ question: PendingQuestion) {
         requestInFlight = true
         cellModels.append(.gettingAnswer)
         chatService.pollForAnswer(question) { [weak self] result in
@@ -84,6 +84,7 @@ class ChatViewModel: ObservableObject {
             case .failure(let error):
                 handleError(error)
             }
+            trackAnswerResponse()
         }
     }
 
@@ -209,6 +210,16 @@ class ChatViewModel: ObservableObject {
         analyticsService.track(event: event)
     }
 
+    func trackChatViewDisappeared() {
+        let event = AppEvent.function(
+            text: "Chat Disappeared",
+            type: "ChatDisappeared",
+            section: "Chat",
+            action: "Chat Disappeared"
+        )
+        analyticsService.track(event: event)
+    }
+
     private func trackMenuAboutTap() {
         let event = AppEvent.buttonNavigation(
             text: String.chat.localized("aboutMenuTitle"),
@@ -220,6 +231,16 @@ class ChatViewModel: ObservableObject {
     private func trackAskQuestionSubmission() {
         let event = AppEvent.chatAskQuestion(
             text: latestQuestion
+        )
+        analyticsService.track(event: event)
+    }
+
+    private func trackAnswerResponse() {
+        let event = AppEvent.function(
+            text: "Chat Question Answer Returned",
+            type: "ChatQuestionAnswerReturned",
+            section: "Chat",
+            action: "Chat Question Answer Returned"
         )
         analyticsService.track(event: event)
     }

--- a/Production/govuk_ios/Views/Chat/ChatView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatView.swift
@@ -47,6 +47,7 @@ struct ChatView: View {
         }
         .onDisappear {
             backgroundOpacity = 0.25
+            viewModel.trackChatViewDisappeared()
         }
         .onTapGesture {
             textAreaFocused = false

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
@@ -11,7 +11,6 @@ struct ChatViewModelTests {
     @Test
     func askQuestion_success_createsCorrectCellModels() async {
         let mockChatService = MockChatService()
-
         mockChatService._stubbedQuestionResult = .success(.pendingQuestion)
         mockChatService._stubbedAnswerResults = [.success(.answeredAnswer)]
         let sut = ChatViewModel(
@@ -31,9 +30,11 @@ struct ChatViewModelTests {
     }
 
     @Test
-    func askQuestion_tracksEvent() async {
+    func askQuestion_tracksAskAndResponseEvents() async {
         let mockChatService = MockChatService()
         let mockAnalyticsService = MockAnalyticsService()
+        mockChatService._stubbedQuestionResult = .success(.pendingQuestion)
+        mockChatService._stubbedAnswerResults = [.success(.answeredAnswer)]
         let sut = ChatViewModel(
             chatService: mockChatService,
             analyticsService: mockAnalyticsService,
@@ -43,10 +44,14 @@ struct ChatViewModelTests {
         sut.latestQuestion = "This is the question"
         sut.askQuestion()
 
-        #expect(mockAnalyticsService._trackedEvents.count == 1)
+        #expect(mockAnalyticsService._trackedEvents.count == 2)
         #expect(
             mockAnalyticsService
                 ._trackedEvents.first?.params?["text"] as? String == "This is the question"
+        )
+        #expect(
+            mockAnalyticsService
+                ._trackedEvents.last?.params?["text"] as? String == "Chat Question Answer Returned"
         )
     }
 
@@ -323,7 +328,7 @@ struct ChatViewModelTests {
     }
 
     @Test
-    func trackMenuClearChatDenyTap_tracksEvent() {
+    func trackChatViewDisappeared_tracksEvent() {
         let mockAnalyticsService = MockAnalyticsService()
         let sut = ChatViewModel(
             chatService: MockChatService(),
@@ -332,8 +337,8 @@ struct ChatViewModelTests {
             handleError: { _ in }
         )
 
-        sut.trackMenuClearChatDenyTap()
+        sut.trackChatViewDisappeared()
         #expect(mockAnalyticsService._trackedEvents.count == 1)
-        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "No, not now")
+        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "Chat Disappeared")
     }
 }


### PR DESCRIPTION
Tracks question answer response. The event can fire when chat isn't visible, however  

Tracks when a user moves off chat window, either in app or when the app is backgrounded. The event can fire when chat isn't visible, so these events and / or events like screen views can be used to work out if a user has moved off the chat window. 

A distinct event leaving will also be useful to calculate the time taken for a user leaves.  

A future piece of work will differentiate between a failed ask question, failed poll or successful poll response. For now we'll return response tracking even if there is an error.