### PR TITLE
govukapp-2319: chat token refresh

### DIFF
--- a/Production/govuk_ios/Extensions/Container/Container+Services.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+Services.swift
@@ -211,8 +211,7 @@ extension Container {
                 serviceClient: self.chatServiceClient.resolve(),
                 chatRepository: self.chatRepository.resolve(),
                 configService: self.appConfigService.resolve(),
-                userDefaultsService: self.userDefaultsService.resolve(),
-                authenticationService: self.authenticationService.resolve()
+                userDefaultsService: self.userDefaultsService.resolve()
             )
         }
     }

--- a/Production/govuk_ios/Extensions/Container/Container+Services.swift
+++ b/Production/govuk_ios/Extensions/Container/Container+Services.swift
@@ -211,7 +211,8 @@ extension Container {
                 serviceClient: self.chatServiceClient.resolve(),
                 chatRepository: self.chatRepository.resolve(),
                 configService: self.appConfigService.resolve(),
-                userDefaultsService: self.userDefaultsService.resolve()
+                userDefaultsService: self.userDefaultsService.resolve(),
+                authenticationService: self.authenticationService.resolve()
             )
         }
     }

--- a/Production/govuk_ios/ServiceClients/Chat/ChatResponseHandler.swift
+++ b/Production/govuk_ios/ServiceClients/Chat/ChatResponseHandler.swift
@@ -3,6 +3,8 @@ import Foundation
 struct ChatResponseHandler: ResponseHandler {
     func handleStatusCode(_ statusCode: Int) -> Error {
         switch statusCode {
+        case 401, 403:
+            ChatError.authenticationError
         case 404:
             ChatError.pageNotFound
         case 422:

--- a/Production/govuk_ios/ServiceClients/Chat/ChatServiceClient.swift
+++ b/Production/govuk_ios/ServiceClients/Chat/ChatServiceClient.swift
@@ -22,6 +22,7 @@ enum ChatError: LocalizedError {
     case apiUnavailable
     case decodingError
     case validationError
+    case authenticationError
 }
 
 struct ChatServiceClient: ChatServiceClientInterface {

--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -42,10 +42,10 @@ class ChatViewModel: ObservableObject {
         scrollToBottom = true
         requestInFlight = true
         chatService.askQuestion(localQuestion) { [weak self] result in
-            self?.cellModels.removeLast()
             self?.requestInFlight = false
             switch result {
             case .success(let pendingQuestion):
+                self?.cellModels.removeLast()
                 let cellModel = ChatCellViewModel(question: pendingQuestion)
                 self?.cellModels.append(cellModel)
                 self?.latestQuestionID = pendingQuestion.id

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/ChatCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/ChatCoordinatorTests.swift
@@ -143,17 +143,75 @@ struct ChatCoordinatorTests {
     }
 
     @Test
-    func handleApiUnavailable_showsWebView() throws {
+    func handlePageNotFoundError_clearsHistory_and_showsChatView() throws {
         let mockChatService = MockChatService()
         mockChatService.setChatOnboarded()
+        mockChatService._clearHistoryCalled = false
         let mockCoordinatorBuilder = MockCoordinatorBuilder(container: .init())
-        let mockSafariCoordinator = MockBaseCoordinator()
-        mockCoordinatorBuilder._stubbedSafariCoordinator = mockSafariCoordinator
-
         let mockViewControllerBuilder = MockViewControllerBuilder()
         let expectedChatViewController = UIViewController()
         let expectedInfoViewController = UIViewController()
         mockViewControllerBuilder._stubbedChatController = expectedChatViewController
+        mockViewControllerBuilder._stubbedChatErrorController = expectedInfoViewController
+        let navigationController = UINavigationController()
+        let sut = ChatCoordinator(
+            navigationController: navigationController,
+            coordinatorBuilder: mockCoordinatorBuilder,
+            viewControllerBuilder: mockViewControllerBuilder,
+            deepLinkStore: DeeplinkDataStore(routes: [], root: UIViewController()),
+            analyticsService: MockAnalyticsService(),
+            chatService: mockChatService,
+            cancelOnboardingAction: { }
+        )
+
+        sut.start(url: nil)
+        mockViewControllerBuilder._receivedHandleChatError?(ChatError.pageNotFound)
+        let firstViewController = navigationController.viewControllers.first
+        #expect(firstViewController == expectedInfoViewController)
+        mockViewControllerBuilder._receivedChatErrorAction?()
+        let nextViewController = navigationController.viewControllers.first
+        #expect(nextViewController == expectedChatViewController)
+        #expect(mockChatService._clearHistoryCalled)
+    }
+
+    @Test
+    func authenticationError_retriesRequest() throws {
+        let mockChatService = MockChatService()
+        mockChatService.setChatOnboarded()
+        let mockCoordinatorBuilder = MockCoordinatorBuilder(container: .init())
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let mockPeriAuthCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedPeriAuthCoordinator = mockPeriAuthCoordinator
+        let navigationController = UINavigationController()
+        let sut = ChatCoordinator(
+            navigationController: navigationController,
+            coordinatorBuilder: mockCoordinatorBuilder,
+            viewControllerBuilder: mockViewControllerBuilder,
+            deepLinkStore: DeeplinkDataStore(routes: [], root: UIViewController()),
+            analyticsService: MockAnalyticsService(),
+            chatService: mockChatService,
+            cancelOnboardingAction: { }
+        )
+
+        var didRetry = false
+        mockChatService._stubbedRetryAction = { didRetry = true }
+        sut.start(url: nil)
+        mockViewControllerBuilder._receivedHandleChatError?(ChatError.authenticationError)
+        mockCoordinatorBuilder._receivedPeriAuthCompletion?()
+        #expect(didRetry)
+        #expect(mockPeriAuthCoordinator._startCalled)
+    }
+
+    @Test
+    func second_authenticationError_showsInfoView() throws {
+        let mockChatService = MockChatService()
+        mockChatService.setChatOnboarded()
+        let mockCoordinatorBuilder = MockCoordinatorBuilder(container: .init())
+        let mockViewControllerBuilder = MockViewControllerBuilder()
+        let mockPeriAuthCoordinator = MockBaseCoordinator()
+        mockCoordinatorBuilder._stubbedPeriAuthCoordinator = mockPeriAuthCoordinator
+
+        let expectedInfoViewController = UIViewController()
         mockViewControllerBuilder._stubbedChatErrorController = expectedInfoViewController
 
         let navigationController = UINavigationController()
@@ -167,13 +225,18 @@ struct ChatCoordinatorTests {
             cancelOnboardingAction: { }
         )
 
+        var didRetry = false
+        mockChatService._stubbedRetryAction = { didRetry = true }
         sut.start(url: nil)
-        mockViewControllerBuilder._receivedHandleChatError?(ChatError.apiUnavailable)
+        mockViewControllerBuilder._receivedHandleChatError?(ChatError.authenticationError)
+        mockCoordinatorBuilder._receivedPeriAuthCompletion?()
+        #expect(didRetry)
+        #expect(mockPeriAuthCoordinator._startCalled)
+        mockViewControllerBuilder._receivedHandleChatError?(ChatError.authenticationError)
         let firstViewController = navigationController.viewControllers.first
         #expect(firstViewController == expectedInfoViewController)
-        mockViewControllerBuilder._receivedChatOpenURLAction?(URL(string: "https://www.gov.uk")!)
-        #expect(mockSafariCoordinator._startCalled)
     }
+
 
     @Test
     func didSelectTab_isShowingError_setsChatViewController() {

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
@@ -95,7 +95,7 @@ struct ChatViewModelTests {
 
         sut.askQuestion()
 
-        #expect(sut.cellModels.count == 0)
+        #expect(sut.cellModels.count == 1)
         #expect(chatError == .pageNotFound)
     }
 
@@ -143,7 +143,7 @@ struct ChatViewModelTests {
         #expect(sut.errorText == nil)
         sut.askQuestion()
 
-        #expect(sut.cellModels.count == 0)
+        #expect(sut.cellModels.count == 1)
         #expect(chatError == nil)
         #expect(sut.errorText != nil)
         #expect(!sut.latestQuestion.isEmpty)

--- a/Tests/govuk_ios/shared/Mocks/Services/MockChatService.swift
+++ b/Tests/govuk_ios/shared/Mocks/Services/MockChatService.swift
@@ -17,6 +17,11 @@ final class MockChatService: ChatServiceInterface {
         _stubbedIsEnabled
     }
 
+    var _stubbedRetryAction: (() -> Void)?
+    var retryAction: (() -> Void)? {
+        _stubbedRetryAction
+    }
+
     var _stubbedQuestionResult: ChatQuestionResult?
     func askQuestion(_ question: String,
                      completion: @escaping (ChatQuestionResult) -> Void) {


### PR DESCRIPTION
Add 401/403 as ChatError.authentication error to ChatResponseHandler
Add a retryAction instance variable to ChatService that is set to the value of whatever service call was just attempted.
If an authenticatonError is received, launch the periAuth coordinator to reauthenticate and on success invoke the retryAction
If the retry attempt after successful reauth also fails with an auhenticationError, show the user the chat error screen.