### PR TITLE
Remove chat disappear event

### DIFF
--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -210,16 +210,6 @@ class ChatViewModel: ObservableObject {
         analyticsService.track(event: event)
     }
 
-    func trackChatViewDisappeared() {
-        let event = AppEvent.function(
-            text: "Chat Disappeared",
-            type: "ChatDisappeared",
-            section: "Chat",
-            action: "Chat Disappeared"
-        )
-        analyticsService.track(event: event)
-    }
-
     private func trackMenuAboutTap() {
         let event = AppEvent.buttonNavigation(
             text: String.chat.localized("aboutMenuTitle"),

--- a/Production/govuk_ios/Views/Chat/ChatView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatView.swift
@@ -47,7 +47,6 @@ struct ChatView: View {
         }
         .onDisappear {
             backgroundOpacity = 0.25
-            viewModel.trackChatViewDisappeared()
         }
         .onTapGesture {
             textAreaFocused = false

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatViewModelTests.swift
@@ -326,19 +326,4 @@ struct ChatViewModelTests {
         #expect(mockAnalyticsService._trackedEvents.count == 1)
         #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "Yes, clear chat")
     }
-
-    @Test
-    func trackChatViewDisappeared_tracksEvent() {
-        let mockAnalyticsService = MockAnalyticsService()
-        let sut = ChatViewModel(
-            chatService: MockChatService(),
-            analyticsService: mockAnalyticsService,
-            openURLAction: { _ in },
-            handleError: { _ in }
-        )
-
-        sut.trackChatViewDisappeared()
-        #expect(mockAnalyticsService._trackedEvents.count == 1)
-        #expect(mockAnalyticsService._trackedEvents.first?.params?["text"] as? String == "Chat Disappeared")
-    }
 }


### PR DESCRIPTION
Tracking whether a user navigates away from chat can be done with other events like tab, or navigation events while the app backgrounded event covers if a user leaves the app entirely. Having a chat disappears event adds noise when navigating in app that should be removed (agreed by PAs).