### PR TITLE
chat token refresh fix

### DIFF
--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -89,6 +89,7 @@ class ChatViewModel: ObservableObject {
     }
 
     func loadHistory() {
+        guard cellModels.isEmpty else { return }
         guard let conversationId = chatService.currentConversationId else {
             cellModels.removeAll()
             appendIntroMessages()

--- a/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatViewModel.swift
@@ -9,6 +9,7 @@ class ChatViewModel: ObservableObject {
     private let openURLAction: (URL) -> Void
     private let handleError: (ChatError) -> Void
     private(set) var requestInFlight: Bool = false
+    private var didLoadHistory: Bool = false
 
     @Published var cellModels: [ChatCellViewModel] = []
     @Published var latestQuestion: String = ""
@@ -45,7 +46,7 @@ class ChatViewModel: ObservableObject {
             self?.requestInFlight = false
             switch result {
             case .success(let pendingQuestion):
-                self?.cellModels.removeLast()
+                self?.cellModels.removeAll(where: { $0.id == ChatCellViewModel.loadingQuestion.id })
                 let cellModel = ChatCellViewModel(question: pendingQuestion)
                 self?.cellModels.append(cellModel)
                 self?.latestQuestionID = pendingQuestion.id
@@ -70,7 +71,7 @@ class ChatViewModel: ObservableObject {
         cellModels.append(.gettingAnswer)
         chatService.pollForAnswer(question) { [weak self] result in
             guard let self else { return }
-            cellModels.removeLast()
+            cellModels.removeAll(where: { $0.id == ChatCellViewModel.gettingAnswer.id })
             requestInFlight = false
             switch result {
             case .success(let answer):
@@ -89,7 +90,9 @@ class ChatViewModel: ObservableObject {
     }
 
     func loadHistory() {
-        guard cellModels.isEmpty else { return }
+        guard !didLoadHistory else {
+            return
+        }
         guard let conversationId = chatService.currentConversationId else {
             cellModels.removeAll()
             appendIntroMessages()
@@ -102,6 +105,7 @@ class ChatViewModel: ObservableObject {
             self?.requestInFlight = false
             switch result {
             case .success(let answers):
+                self?.didLoadHistory = true
                 self?.handleHistoryResponse(answers)
             case .failure(let error):
                 if error == .pageNotFound {

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/ChatViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/ChatViewControllerSnapshotTests.swift
@@ -99,7 +99,6 @@ final class ChatViewControllerSnapshotTests: SnapshotTestCase {
             viewModel.errorText = String.chat.localized("validationErrorText")
         }
         
-        viewModel.cellModels.append(.gettingAnswer)
         let view = ChatView(viewModel: viewModel)
             .environment(\.isTesting, true)
         return view


### PR DESCRIPTION
If a users refresh token was bad and they needed to do a full auth, after auth the chat history would be refetched when the chatView appeared.  This could result in out of order or repeated messages.
Only fetch history once, as there should be no need to do more than once in a user session.  Also, make sure it is the placeholder cell that is removed, as retrying requests could wind up with the last cell in the list not being a placeholder