### PR TITLE
govukapp-2487: Chat refresh token change

### DIFF
--- a/Production/govuk_ios/Coordinators/Launch/AppCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/Launch/AppCoordinator.swift
@@ -41,6 +41,7 @@ class AppCoordinator: BaseCoordinator {
         inactivityService.startMonitoring(
             inactivityHandler: { [weak self] in
                 self?.root.dismiss(animated: true)
+                self?.authenticationService.clearRefreshToken()
                 self?.startPeriAuthCoordinator()
             }
         )

--- a/Production/govuk_ios/Services/AuthenticationService.swift
+++ b/Production/govuk_ios/Services/AuthenticationService.swift
@@ -18,6 +18,7 @@ protocol AuthenticationServiceInterface: AnyObject {
     func signOut(reason: SignoutReason)
     func encryptRefreshToken()
     func tokenRefreshRequest() async -> TokenRefreshResult
+    func clearRefreshToken()
 }
 
 struct AuthenticationServiceResponse {
@@ -84,19 +85,6 @@ class AuthenticationService: AuthenticationServiceInterface {
         }
     }
 
-    private func handleReturningUser() async -> AuthenticationServiceResult {
-        let returningUserResult = await returningUserService.process(
-            idToken: idToken
-        )
-        switch returningUserResult {
-        case .success(let isReturning):
-            return .success(.init(returningUser: isReturning))
-        case .failure(let error):
-            setTokens()
-            return .failure(.returningUserService(error))
-        }
-    }
-
     func signOut(reason: SignoutReason) {
         do {
             try authenticatedSecureStoreService.delete()
@@ -130,7 +118,7 @@ class AuthenticationService: AuthenticationServiceInterface {
     func tokenRefreshRequest() async -> TokenRefreshResult {
         var decryptedRefreshToken: String
         do {
-            decryptedRefreshToken = try decryptRefreshToken()
+            decryptedRefreshToken = try decryptRefreshTokenIfRequired()
         } catch {
             return .failure(.decryptRefreshTokenError)
         }
@@ -151,10 +139,30 @@ class AuthenticationService: AuthenticationServiceInterface {
         }
     }
 
-    private func decryptRefreshToken() throws -> String {
-        let fetchedRefreshToken =
-        try authenticatedSecureStoreService.readItem(itemName: "refreshToken")
-        return fetchedRefreshToken
+    func clearRefreshToken() {
+        refreshToken = nil
+    }
+
+    private func handleReturningUser() async -> AuthenticationServiceResult {
+        let returningUserResult = await returningUserService.process(
+            idToken: idToken
+        )
+        switch returningUserResult {
+        case .success(let isReturning):
+            return .success(.init(returningUser: isReturning))
+        case .failure(let error):
+            setTokens()
+            return .failure(.returningUserService(error))
+        }
+    }
+
+    private func decryptRefreshTokenIfRequired() throws -> String {
+        guard let token = refreshToken else {
+            let fetchedRefreshToken =
+            try authenticatedSecureStoreService.readItem(itemName: "refreshToken")
+            return fetchedRefreshToken
+        }
+        return token
     }
 
     private func setTokens(refreshToken: String? = nil,

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Services/MockAuthenticationService.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Services/MockAuthenticationService.swift
@@ -5,6 +5,7 @@ import Authentication
 @testable import govuk_ios
 
 class MockAuthenticationService: AuthenticationServiceInterface {
+
     var _storedRefreshToken = true
     var secureStoreRefreshTokenPresent: Bool {
         _storedRefreshToken
@@ -59,5 +60,9 @@ class MockAuthenticationService: AuthenticationServiceInterface {
     var _stubbedShouldAttemptTokenRefresh: Bool = true
     var shouldAttemptTokenRefresh: Bool {
         _stubbedShouldAttemptTokenRefresh
+    }
+
+    func clearRefreshToken() {
+        refreshToken = nil
     }
 }


### PR DESCRIPTION
By default, use memory cached refreshToken for access token refresh requests
Add ability to clear cached token for purposes of inactivity timeouts.  This forces local authentication again.
Update tests