### PR TITLE
Handle chat token refresh when biometrics not enrolled

### DIFF
--- a/Production/govuk_ios/Coordinators/Launch/ReAuthenticationCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/Launch/ReAuthenticationCoordinator.swift
@@ -36,7 +36,11 @@ class ReAuthenticationCoordinator: BaseCoordinator {
             .deviceOwnerAuthenticationWithBiometrics
         )
         guard policy.canEvaluate else {
-            completionAction()
+            if authenticationService.isSignedIn {
+                await sendRefreshRequest()
+            } else {
+                completionAction()
+            }
             return
         }
         guard !localAuthenticationService.biometricsHaveChanged else {
@@ -53,6 +57,10 @@ class ReAuthenticationCoordinator: BaseCoordinator {
             return
         }
 
+        await sendRefreshRequest()
+    }
+
+    private func sendRefreshRequest() async {
         let refreshRequestResult = await authenticationService.tokenRefreshRequest()
 
         switch refreshRequestResult {


### PR DESCRIPTION
We recently made a change to use the refresh token that is held in the authentication service for getting a new access token, rather than requiring the user to fetch the refresh token from the secure store to get the new token.  This was so chat users were not faced with an biometrics request every 5 minutes.

After this change, users who were not enrolled in biometrics were not able to reauthenticate, as the logic we had implemented would not attempt a token refresh at all if biometrics weren't enrolled, because no secure store meant no refesh token would be available.  This ultimately resulted in an error screen being presented to the user

The fix is to check for presence of the refresh token in RAM (i.e. authenticatonService.isSignedIn), and if it's available, attempt a token refresh, otherwise fall back to what we had before (a full login).