### PR TITLE
govukapp-2529:  chat opt in analytics

### DIFF
--- a/Production/govuk_ios/ViewControllers/HomeContentViewController.swift
+++ b/Production/govuk_ios/ViewControllers/HomeContentViewController.swift
@@ -9,6 +9,8 @@ class HomeContentViewController: BaseViewController,
     private let viewModel: HomeViewModel
     private var cancellables = Set<AnyCancellable>()
 
+    private let threadSafeChatOptedIn: Bool
+
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -33,6 +35,7 @@ class HomeContentViewController: BaseViewController,
 
     public init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
+        threadSafeChatOptedIn = viewModel.userDefaultService.bool(forKey: .chatOptedIn)
         super.init(analyticsService: viewModel.analyticsService)
         title = String.home.localized("pageTitle")
     }
@@ -113,6 +116,12 @@ class HomeContentViewController: BaseViewController,
 }
 
 extension HomeContentViewController: TrackableScreen {
+    nonisolated var isChatOptedIn: String {
+        threadSafeChatOptedIn ? "chatOptIn" : "chatOptOut"
+    }
     var trackingName: String { "Homepage" }
     var trackingTitle: String? { "Homepage" }
+    var additionalParameters: [String: Any] {
+        ["type": isChatOptedIn]
+    }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/HomeContentViewControllerTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewControllers/HomeContentViewControllerTests.swift
@@ -41,8 +41,14 @@ struct HomeContentViewControllerTests {
         #expect(subject.title == "Home")
     }
 
-    @Test
-    func viewDidAppear_tracksScreen() {
+    @Test(arguments: zip(
+        [true, false],
+        ["chatOptIn", "chatOptOut"]
+    ))
+    func viewDidAppear_tracksScreen(chatOptedIn: Bool,
+                                    expectedValue: String) {
+        let mockUserDefaultsService = MockUserDefaultsService()
+        mockUserDefaultsService.set(bool: chatOptedIn, forKey: .chatOptedIn)
         let mockAnalyticsService = MockAnalyticsService()
         let topicsViewModel = TopicsWidgetViewModel(
             topicsService: MockTopicsService(),
@@ -67,7 +73,7 @@ struct HomeContentViewControllerTests {
             searchService: MockSearchService(),
             activityService: MockActivityService(),
             localAuthorityService: MockLocalAuthorityService(),
-            userDefaultService: MockUserDefaultsService()
+            userDefaultService: mockUserDefaultsService
         )
         let subject = HomeContentViewController(viewModel: viewModel)
         subject.viewDidAppear(false)
@@ -76,7 +82,8 @@ struct HomeContentViewControllerTests {
         #expect(screens.count == 1)
         #expect(screens.first?.trackingName == subject.trackingName)
         #expect(screens.first?.trackingClass == subject.trackingClass)
-        #expect(screens.first?.additionalParameters.count == 0)
+        #expect(screens.first?.additionalParameters.count == 1)
+        #expect((screens.first?.additionalParameters["type"] as? String) == expectedValue)
     }
     
     @Test


### PR DESCRIPTION
Add a type parameter to home screen tracking that specifies chat opt in status.

This required creation of cached value of the opt in status for thread safety reasons.

The implementation may need to be revisited if user is allowed to change their status after initial onboarding - e.g. if a switch is added to settings.