### PR TITLE
GOVUKAPP-2531 Popular pages duplication bug 

### DIFF
--- a/Production/govuk_ios/ViewModels/Topics/StepByStepsViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/StepByStepsViewModel.swift
@@ -58,7 +58,7 @@ class StepByStepsViewModel: TopicDetailViewModelInterface {
             category: String.topics.localized("topicDetailStepByStepHeader")
         )
         return LinkRow(
-            id: content.title,
+            id: UUID().uuidString,
             title: content.title,
             body: nil,
             action: { [weak self] in

--- a/Production/govuk_ios/ViewModels/Topics/TopicDetailViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Topics/TopicDetailViewModel.swift
@@ -185,7 +185,7 @@ class TopicDetailViewModel: TopicDetailViewModelInterface {
                                   sectionTitle: String) -> LinkRow {
         createCommerceItem(content, category: sectionTitle)
         return LinkRow(
-            id: content.title,
+            id: UUID().uuidString,
             title: content.title,
             body: nil,
             action: {


### PR DESCRIPTION
Popular pages duplication bug 

- Use 'UUID' rather than 'content title' as the identifiable 'id' as some content titles are the same causing id conflict (this bug).

[Jira link](https://govukverify.atlassian.net/browse/GOVUKAPP-2531)