### PR TITLE
govukapp-2547: Conditionally show chat accuracy warning

### DIFF
--- a/Production/govuk_ios/Views/Chat/ChatCellView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatCellView.swift
@@ -109,14 +109,15 @@ struct ChatCellView: View {
             HStack(alignment: .firstTextBaseline) {
                 markdownView
             }
-            Divider()
-                .overlay(Color(UIColor.govUK.strokes.chatDivider))
-                .padding(.vertical, 8)
-            warningView
             if !viewModel.sources.isEmpty {
+                Divider()
+                    .overlay(Color(UIColor.govUK.strokes.chatDivider))
+                    .padding(.vertical, 8)
+                warningView
                 sourceView
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
     }
 

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.ChatViewControllerSnapshotTests/test_loadInNavigationController_noSources_dark_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.ChatViewControllerSnapshotTests/test_loadInNavigationController_noSources_dark_rendersCorrectly@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:853962ed304083ef98504eb54b73ac317af00e090cc8eee39ed59c58532ed567
+size 367893

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.ChatViewControllerSnapshotTests/test_loadInNavigationController_noSources_light_rendersCorrectly@3x.png
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/ReferenceImages_64/govuk_ios_snapshot_tests.ChatViewControllerSnapshotTests/test_loadInNavigationController_noSources_light_rendersCorrectly@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88d46e79ac30ab9fa1b9793ae84d3c1893abf804db92d2dc6810f38df9215c8e
+size 537819

--- a/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/ChatViewControllerSnapshotTests.swift
+++ b/Tests/govuk_ios/govuk_ios_snapshot_tests/Specs/ViewControllers/ChatViewControllerSnapshotTests.swift
@@ -24,6 +24,22 @@ final class ChatViewControllerSnapshotTests: SnapshotTestCase {
         )
     }
 
+    func test_loadInNavigationController_noSources_light_rendersCorrectly() {
+        VerifySnapshotInNavigationController(
+            view: view(includeSources: false),
+            mode: .light,
+            navBarHidden: true
+        )
+    }
+
+    func test_loadInNavigationController_noSources_dark_rendersCorrectly() {
+        VerifySnapshotInNavigationController(
+            view: view(includeSources: false),
+            mode: .dark,
+            navBarHidden: true
+        )
+    }
+
     func test_loadInNavigationController_showError_light_rendersCorrectly() {
         VerifySnapshotInNavigationController(
             view: view(showError: true),
@@ -99,7 +115,8 @@ final class ChatViewControllerSnapshotTests: SnapshotTestCase {
         )
     }
 
-    private func view(showError: Bool = false) -> some View {
+    private func view(showError: Bool = false,
+                      includeSources: Bool = true) -> some View {
         let mockChatService = MockChatService()
         let conversationId = "conversationId"
         let createdAt = "\(Date())"
@@ -118,7 +135,7 @@ final class ChatViewControllerSnapshotTests: SnapshotTestCase {
             createdAt: createdAt,
             id: "12345",
             message: "This is the answer",
-            sources: sources
+            sources: includeSources ? sources : nil
         )
 
         let answeredQuestion = AnsweredQuestion(


### PR DESCRIPTION
Only show chat accuracy warning if there are source links included in response.
Add tests for no sources case