### PR TITLE
govvukapp-2048:  Chat copy to clipboard

### DIFF
--- a/Production/govuk_ios/Resources/Strings/Chat.xcstrings
+++ b/Production/govuk_ios/Resources/Strings/Chat.xcstrings
@@ -89,6 +89,17 @@
         }
       }
     },
+    "copyToClipboardTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy to clipboard"
+          }
+        }
+      }
+    },
     "feedbackMenuAccessibilityTitle" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Production/govuk_ios/ViewModels/Chat/ChatCellViewModel.swift
+++ b/Production/govuk_ios/ViewModels/Chat/ChatCellViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import UIComponents
 import GOVKit
+import MarkdownUI
 
 enum ChatLinkType: String {
     case sourceLink = "Source Link"
@@ -93,6 +94,17 @@ class ChatCellViewModel: ObservableObject {
 
     var questionWidth: CGFloat {
         UIScreen.main.bounds.width * 0.2
+    }
+
+    func copyToClipboard() {
+        var textToCopy = MarkdownContent(message).renderPlainText()
+        if !sources.isEmpty {
+            textToCopy.append("\n\n" + String.chat.localized("mistakesTitle"))
+            sources.forEach { source in
+                textToCopy.append("\n\n" + source.url)
+            }
+        }
+        UIPasteboard.general.string = textToCopy
     }
 
     func openURL(url: URL, type: ChatLinkType) {

--- a/Production/govuk_ios/Views/Chat/ChatCellView.swift
+++ b/Production/govuk_ios/Views/Chat/ChatCellView.swift
@@ -31,6 +31,14 @@ struct ChatCellView: View {
         .animation(.easeIn(duration: duration).delay(delay),
                    value: viewModel.isVisible)
         .clipShape(RoundedRectangle(cornerRadius: 10))
+        .contextMenu {
+            Button(action: {
+                viewModel.copyToClipboard()
+            }, label: {
+                Text(String.chat.localized("copyToClipboardTitle"))
+                Image(systemName: "doc.on.doc.fill")
+            })
+        }
     }
 
     private var anchor: UnitPoint {

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatCellViewModelTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/ViewModels/ChatCellViewModelTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Testing
 import GOVKit
 
@@ -87,5 +88,46 @@ struct ChatCellViewModelTests {
 
         sut.trackSourceListToggle(isExpanded: false)
         #expect(mockAnalyticsService._trackedEvents.count == 0)
+    }
+
+    @Test
+    func copytoClipboard_copiesExpectedText() async {
+        let mockAnalyticsService = MockAnalyticsService()
+        let markdownText = """
+            ## Heading
+            * Bullet 1
+            * Bullet 2
+            # Heading 2
+            paragraph
+            """
+        let source = Source(title: "Source Title", url: "https://example.com")
+
+
+        let sut = ChatCellViewModel(
+            message: markdownText,
+            id: UUID().uuidString,
+            type: .answer,
+            sources: [source],
+            openURLAction: { _ in },
+            analyticsService: mockAnalyticsService
+        )
+        sut.copyToClipboard()
+
+        let expectedText = """
+            Heading
+            
+              - Bullet 1
+              - Bullet 2
+            
+            Heading 2
+            
+            paragraph
+            
+            GOV.UK Chat can make mistakes. Check GOV.UK pages for important information.
+            
+            https://example.com
+            """
+
+        #expect(UIPasteboard.general.string ?? "" == expectedText)
     }
 }


### PR DESCRIPTION
Add context menu to chat cells allowing copy to clipboard.
Markdown is stripped before copying
Includes accuracy warning and links when required