### PR TITLE
Govukapp-2450: Show loading indicator during login while waiting for auth to finish

### DIFF
--- a/Production/govuk_ios/Builders/ViewControllerBuilder.swift
+++ b/Production/govuk_ios/Builders/ViewControllerBuilder.swift
@@ -465,8 +465,7 @@ class ViewControllerBuilder {
         return viewController
     }
 
-    func welcomeOnboarding(viewModel: WelcomeOnboardingViewModel,
-                           completion: @escaping () -> Void) -> UIViewController {
+    func welcomeOnboarding(viewModel: WelcomeOnboardingViewModel) -> UIViewController {
         let containerView = InfoView(
             viewModel: viewModel
         )

--- a/Production/govuk_ios/Builders/ViewControllerBuilder.swift
+++ b/Production/govuk_ios/Builders/ViewControllerBuilder.swift
@@ -301,7 +301,7 @@ class ViewControllerBuilder {
         let viewModel = SignInErrorViewModel(
             completion: completion
         )
-        let view = InfoView(viewModel: viewModel)
+        let view = InfoView<SignInErrorViewModel>(viewModel: viewModel)
         let viewController = HostingViewController(rootView: view)
         return viewController
     }
@@ -443,7 +443,7 @@ class ViewControllerBuilder {
             error: error,
             action: action
         )
-        let view = InfoView(viewModel: viewModel)
+        let view = InfoView<ChatErrorViewModel>(viewModel: viewModel)
         let viewController = HostingViewController(
             rootView: view,
             navigationBarHidden: true
@@ -465,10 +465,8 @@ class ViewControllerBuilder {
         return viewController
     }
 
-    func welcomeOnboarding(completion: @escaping () -> Void) -> UIViewController {
-        let viewModel = WelcomeOnboardingViewModel(
-            completeAction: completion
-        )
+    func welcomeOnboarding(viewModel: WelcomeOnboardingViewModel,
+                           completion: @escaping () -> Void) -> UIViewController {
         let containerView = InfoView(
             viewModel: viewModel
         )
@@ -504,7 +502,7 @@ class ViewControllerBuilder {
             completionAction: completionAction,
             cancelOnboardingAction: cancelOnboardingAction
         )
-        let containerView = InfoView(
+        let containerView = InfoView<ChatInfoOnboardingViewModel>(
             viewModel: viewModel
         )
         let viewController = HostingViewController(
@@ -527,7 +525,7 @@ class ViewControllerBuilder {
             cancelOnboardingAction: cancelOnboardingAction,
             completionAction: completionAction
         )
-        let containerView = InfoView(
+        let containerView = InfoView<ChatConsentOnboardingViewModel>(
             viewModel: viewModel,
             customView: {
                 AnyView(InfoIconListView(
@@ -577,7 +575,7 @@ class ViewControllerBuilder {
             ],
             openURLAction: openURLAction
         )
-        let containerView = InfoView(
+        let containerView = InfoView<ChatOptInViewModel>(
             viewModel: viewModel,
             customView: { AnyView(linksView) }
         )
@@ -606,7 +604,7 @@ class ViewControllerBuilder {
             ],
             openURLAction: openURLAction
         )
-        let containerView = InfoView(
+        let containerView = InfoView<ChatOffboardingViewModel>(
             viewModel: viewModel,
             customView: { AnyView(linksView) }
         )

--- a/Production/govuk_ios/Coordinators/Launch/WelcomeOnboardingCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/Launch/WelcomeOnboardingCoordinator.swift
@@ -12,6 +12,15 @@ class WelcomeOnboardingCoordinator: BaseCoordinator {
     private var pendingAuthenticationCoordinator: BaseCoordinator?
     private let completionAction: () -> Void
 
+    private lazy var weclomeOnboardingViewModel: WelcomeOnboardingViewModel = {
+        let viewModel = WelcomeOnboardingViewModel(
+            completeAction: { [weak self] in
+                self?.startAuthentication()
+            }
+        )
+        return viewModel
+    }()
+
     init(navigationController: UINavigationController,
          authenticationService: AuthenticationServiceInterface,
          coordinatorBuilder: CoordinatorBuilder,
@@ -36,6 +45,7 @@ class WelcomeOnboardingCoordinator: BaseCoordinator {
 
     private func setWelcomeOnboardingViewController(_ animated: Bool = true) {
         let viewController = viewControllerBuilder.welcomeOnboarding(
+            viewModel: weclomeOnboardingViewModel,
             completion: { [weak self] in
                 self?.startAuthentication()
             }
@@ -58,6 +68,7 @@ class WelcomeOnboardingCoordinator: BaseCoordinator {
 
     private func showError(_ error: AuthenticationError) {
         pendingAuthenticationCoordinator = nil
+        weclomeOnboardingViewModel.showProgressView = false
         guard case .loginFlow(.userCancelled) = error else {
             analyticsService.track(error: error)
             setSignInError()

--- a/Production/govuk_ios/Coordinators/Launch/WelcomeOnboardingCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/Launch/WelcomeOnboardingCoordinator.swift
@@ -12,7 +12,7 @@ class WelcomeOnboardingCoordinator: BaseCoordinator {
     private var pendingAuthenticationCoordinator: BaseCoordinator?
     private let completionAction: () -> Void
 
-    private lazy var weclomeOnboardingViewModel: WelcomeOnboardingViewModel = {
+    private lazy var welcomeOnboardingViewModel: WelcomeOnboardingViewModel = {
         let viewModel = WelcomeOnboardingViewModel(
             completeAction: { [weak self] in
                 self?.startAuthentication()
@@ -45,10 +45,7 @@ class WelcomeOnboardingCoordinator: BaseCoordinator {
 
     private func setWelcomeOnboardingViewController(_ animated: Bool = true) {
         let viewController = viewControllerBuilder.welcomeOnboarding(
-            viewModel: weclomeOnboardingViewModel,
-            completion: { [weak self] in
-                self?.startAuthentication()
-            }
+            viewModel: welcomeOnboardingViewModel
         )
         set(viewController)
     }
@@ -68,7 +65,7 @@ class WelcomeOnboardingCoordinator: BaseCoordinator {
 
     private func showError(_ error: AuthenticationError) {
         pendingAuthenticationCoordinator = nil
-        weclomeOnboardingViewModel.showProgressView = false
+        welcomeOnboardingViewModel.showProgressView = false
         guard case .loginFlow(.userCancelled) = error else {
             analyticsService.track(error: error)
             setSignInError()

--- a/Production/govuk_ios/Coordinators/SignInSuccessCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/SignInSuccessCoordinator.swift
@@ -23,7 +23,7 @@ final class SignInSuccessCoordinator: BaseCoordinator {
             }
         )
 
-        let containerView = InfoView(
+        let containerView = InfoView<SignInSuccessViewModel>(
             viewModel: viewModel
         )
         let viewController = UIHostingController(

--- a/Production/govuk_ios/ViewModels/InfoViewModelInterface.swift
+++ b/Production/govuk_ios/ViewModels/InfoViewModelInterface.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import GOVKit
 import UIComponents
 
-protocol InfoViewModelInterface {
+protocol InfoViewModelInterface: ObservableObject {
     var analyticsService: AnalyticsServiceInterface? { get }
     var trackingName: String { get }
     var trackingTitle: String { get }
@@ -28,6 +28,11 @@ protocol InfoViewModelInterface {
     var secondaryButtonAccessibilityTitle: String { get }
     var secondaryButtonViewModel: GOVUKButton.ButtonViewModel? { get }
     var secondaryButtonConfiguration: GOVUKButton.ButtonConfiguration { get }
+}
+
+protocol ProgressIndicating {
+    var showProgressView: Bool { get set }
+    var animationDelay: TimeInterval { get }
 }
 
 extension InfoViewModelInterface {

--- a/Production/govuk_ios/ViewModels/WelcomeOnboardingViewModel.swift
+++ b/Production/govuk_ios/ViewModels/WelcomeOnboardingViewModel.swift
@@ -3,8 +3,11 @@ import GOVKit
 import UIComponents
 import SwiftUI
 
-final class WelcomeOnboardingViewModel: InfoViewModelInterface {
+final class WelcomeOnboardingViewModel: InfoViewModelInterface,
+                                        ProgressIndicating {
     private let completeAction: () -> Void
+
+    @Published var showProgressView: Bool = false
 
     init(completeAction: @escaping () -> Void) {
         self.completeAction = completeAction
@@ -31,6 +34,7 @@ final class WelcomeOnboardingViewModel: InfoViewModelInterface {
         return .init(
             localisedTitle: localTitle,
             action: { [weak self] in
+                self?.showProgressView = true
                 self?.completeAction()
             }
         )
@@ -51,5 +55,9 @@ final class WelcomeOnboardingViewModel: InfoViewModelInterface {
         guard let versionNumber = Bundle.main.versionNumber
         else { return "" }
         return "\(String.onboarding.localized("appVersionText")) \(versionNumber)"
+    }
+
+    var animationDelay: TimeInterval {
+        showProgressView ? 1.0 : 0.0
     }
 }

--- a/Production/govuk_ios/ViewModels/WelcomeOnboardingViewModel.swift
+++ b/Production/govuk_ios/ViewModels/WelcomeOnboardingViewModel.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 final class WelcomeOnboardingViewModel: InfoViewModelInterface,
                                         ProgressIndicating {
-    private let completeAction: () -> Void
+    let completeAction: () -> Void
 
     @Published var showProgressView: Bool = false
 

--- a/Production/govuk_ios/Views/Common/Info/InfoView.swift
+++ b/Production/govuk_ios/Views/Common/Info/InfoView.swift
@@ -2,14 +2,14 @@ import SwiftUI
 import GOVKit
 import UIComponents
 
-struct InfoView: View {
+struct InfoView<Model>: View where Model: InfoViewModelInterface {
     @Environment(\.verticalSizeClass) var verticalSizeClass
-    private var viewModel: any InfoViewModelInterface
+    @StateObject private var viewModel: Model
     private let customView: (() -> AnyView)?
 
-    init(viewModel: any InfoViewModelInterface,
+    init(viewModel: Model,
          customView: (() -> AnyView)? = nil) {
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
         self.customView = customView
     }
 
@@ -44,10 +44,34 @@ struct InfoView: View {
                 .padding(16)
             }
         }
+        .overlay(content: {
+            ZStack {
+                Color(UIColor(light: .white, dark: .black))
+                ProgressView()
+            }
+            .opacity(progressOpacity)
+            .animation(.easeOut.delay(delay),
+                       value: progressOpacity)
+            .ignoresSafeArea()
+        })
         .navigationBarHidden(viewModel.navBarHidden)
         .onAppear {
             viewModel.trackScreen(screen: self)
         }
+    }
+
+    private var progressOpacity: CGFloat {
+        guard let model = viewModel as? ProgressIndicating else {
+            return 0.0
+        }
+        return model.showProgressView ? 1.0 : 0.0
+    }
+
+    private var delay: TimeInterval {
+        guard let model = viewModel as? ProgressIndicating else {
+            return 0.0
+        }
+        return model.animationDelay
     }
 
     private var infoView: some View {

--- a/Production/govuk_ios/Views/Common/Info/InfoView.swift
+++ b/Production/govuk_ios/Views/Common/Info/InfoView.swift
@@ -9,7 +9,7 @@ struct InfoView<Model>: View where Model: InfoViewModelInterface {
 
     init(viewModel: Model,
          customView: (() -> AnyView)? = nil) {
-        self._viewModel = StateObject(wrappedValue: viewModel)
+        _viewModel = StateObject(wrappedValue: viewModel)
         self.customView = customView
     }
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
@@ -203,8 +203,13 @@ class MockViewControllerBuilder: ViewControllerBuilder {
     }
 
     var _stubbedWelcomeOnboardingViewController: UIViewController?
+    var _stubbedWelcomeOnboardingViewModel: WelcomeOnboardingViewModel?
     var _receivedWelcomeOnboardingCompletion: (() -> Void)?
-    override func welcomeOnboarding(completion: @escaping () -> Void) -> UIViewController {
+    override func welcomeOnboarding(
+        viewModel: WelcomeOnboardingViewModel,
+        completion: @escaping () -> Void
+    ) -> UIViewController {
+        _stubbedWelcomeOnboardingViewModel = viewModel
         _receivedWelcomeOnboardingCompletion = completion
         return _stubbedWelcomeOnboardingViewController ?? UIViewController()
     }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Mocks/Builders/MockViewControllerBuilder.swift
@@ -204,13 +204,10 @@ class MockViewControllerBuilder: ViewControllerBuilder {
 
     var _stubbedWelcomeOnboardingViewController: UIViewController?
     var _stubbedWelcomeOnboardingViewModel: WelcomeOnboardingViewModel?
-    var _receivedWelcomeOnboardingCompletion: (() -> Void)?
     override func welcomeOnboarding(
-        viewModel: WelcomeOnboardingViewModel,
-        completion: @escaping () -> Void
+        viewModel: WelcomeOnboardingViewModel
     ) -> UIViewController {
         _stubbedWelcomeOnboardingViewModel = viewModel
-        _receivedWelcomeOnboardingCompletion = completion
         return _stubbedWelcomeOnboardingViewController ?? UIViewController()
     }
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
@@ -226,7 +226,8 @@ struct ViewControllerBuilderTests {
         let result = subject.signInError(
             completion: { }
         )
-        let rootView = (result as? HostingViewController<InfoView>)?.rootView
+        let rootView =
+        (result as? HostingViewController<InfoView<SignInErrorViewModel>>)?.rootView
         #expect(rootView != nil)
     }
 
@@ -244,10 +245,13 @@ struct ViewControllerBuilderTests {
     func welcomeOnboarding_returnsExpectedResult() {
         let subject = ViewControllerBuilder()
         let result = subject.welcomeOnboarding(
+            viewModel: WelcomeOnboardingViewModel(
+                completeAction: { }
+            ),
             completion: { }
         )
 
-        let rootView = (result as? HostingViewController<InfoView>)?.rootView
+        let rootView = (result as? HostingViewController<InfoView<WelcomeOnboardingViewModel>>)?.rootView
         #expect(rootView != nil)
     }
 
@@ -316,7 +320,7 @@ struct ViewControllerBuilderTests {
             action: { }
         )
         
-        let rootView = (result as? HostingViewController<InfoView>)?.rootView
+        let rootView = (result as? HostingViewController<InfoView<ChatErrorViewModel>>)?.rootView
         #expect(rootView != nil)
     }
 
@@ -329,7 +333,8 @@ struct ViewControllerBuilderTests {
             cancelOnboardingAction: { }
         )
 
-        let rootView = (result as? HostingViewController<InfoView>)?.rootView
+        let rootView =
+        (result as? HostingViewController<InfoView<ChatInfoOnboardingViewModel>>)?.rootView
         #expect(rootView != nil)
     }
 
@@ -343,7 +348,8 @@ struct ViewControllerBuilderTests {
             completionAction: { }
         )
 
-        let rootView = (result as? HostingViewController<InfoView>)?.rootView
+        let rootView =
+        (result as? HostingViewController<InfoView<ChatConsentOnboardingViewModel>>)?.rootView
         #expect(rootView != nil)
     }
 
@@ -357,7 +363,8 @@ struct ViewControllerBuilderTests {
             completionAction: { }
         )
 
-        let rootView = (result as? HostingViewController<InfoView>)?.rootView
+        let rootView =
+        (result as? HostingViewController<InfoView<ChatOptInViewModel>>)?.rootView
         #expect(rootView != nil)
     }
 
@@ -371,7 +378,8 @@ struct ViewControllerBuilderTests {
             completionAction: { }
         )
 
-        let rootView = (result as? HostingViewController<InfoView>)?.rootView
+        let rootView =
+        (result as? HostingViewController<InfoView<ChatOffboardingViewModel>>)?.rootView
         #expect(rootView != nil)
     }
 }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Builders/ViewControllerBuilderTests.swift
@@ -247,8 +247,7 @@ struct ViewControllerBuilderTests {
         let result = subject.welcomeOnboarding(
             viewModel: WelcomeOnboardingViewModel(
                 completeAction: { }
-            ),
-            completion: { }
+            )
         )
 
         let rootView = (result as? HostingViewController<InfoView<WelcomeOnboardingViewModel>>)?.rootView

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/WelcomeOnboardingCoordinatorTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Coordinators/WelcomeOnboardingCoordinatorTests.swift
@@ -73,7 +73,7 @@ class WelcomeOnboardingCoordinatorTests {
 
         sut.start(url: nil)
 
-        mockViewControllerBuilder._receivedWelcomeOnboardingCompletion?()
+        mockViewControllerBuilder._stubbedWelcomeOnboardingViewModel?.completeAction()
         mockCoordinatorBuilder._receivedAuthenticationHandleError?(.loginFlow(.accessDenied))
 
         #expect(mockNavigationController._setViewControllers?.first == stubbedSignInErrorViewController)
@@ -105,7 +105,7 @@ class WelcomeOnboardingCoordinatorTests {
         sut.start(url: nil)
 
         let expectedError = AuthenticationError.loginFlow(.accessDenied)
-        mockViewControllerBuilder._receivedWelcomeOnboardingCompletion?()
+        mockViewControllerBuilder._stubbedWelcomeOnboardingViewModel?.completeAction()
         mockCoordinatorBuilder._receivedAuthenticationHandleError?(expectedError)
 
         #expect((mockAnalyticsService._trackErrorReceivedErrors.first as? AuthenticationError) == expectedError)
@@ -135,7 +135,6 @@ class WelcomeOnboardingCoordinatorTests {
 
         sut.start(url: nil)
 
-        mockViewControllerBuilder._receivedWelcomeOnboardingCompletion?()
         mockCoordinatorBuilder._receivedAuthenticationHandleError?(.loginFlow(.userCancelled))
 
         #expect(mockNavigationController._setViewControllers?.first == stubbedWelcomeOnboardingViewController)
@@ -165,7 +164,6 @@ class WelcomeOnboardingCoordinatorTests {
 
         sut.start(url: nil)
 
-        mockViewControllerBuilder._receivedWelcomeOnboardingCompletion?()
         mockCoordinatorBuilder._receivedAuthenticationHandleError?(.loginFlow(.accessDenied))
         mockViewControllerBuilder._receivedSignInErrorCompletion?()
 


### PR DESCRIPTION
In order to show a loading indicator while we wait for authentication to finish,  InfoView has been modified to overlay the indicator if supported by the view model.
- A new protocol, ProgressIndicating, was added to optionally show/hide a loading indicator overlay on the Infoview.  If the viewModel for the InfoView implements this protocol (in addition to InfoViewModelProtocol), then it can control the presentation of the loading indicator.  As well as showing and hiding, the presentation can be delayed.  This was added so that the loading indicator does not appear before the authentication modal has been fully presented.
- In order for this to work, InfoViewModelProtocol needs to be an ObservableObject.  Swift requires ObservableObjects to be concrete implementations, so it was necessary to genericise InfoView in order to be able to specify the model class.