### PR TITLE
Fix return user missing issue.

### DIFF
--- a/Production/govuk_ios/Services/Analytics/AnalyticsService.swift
+++ b/Production/govuk_ios/Services/Analytics/AnalyticsService.swift
@@ -30,6 +30,7 @@ class AnalyticsService: AnalyticsServiceInterface {
     }
 
     func track(error: Error) {
+        guard shouldTrack else { return }
         clients.forEach { $0.track(error: error) }
     }
 

--- a/Production/govuk_ios/Services/ReturningUserService.swift
+++ b/Production/govuk_ios/Services/ReturningUserService.swift
@@ -12,7 +12,7 @@ class ReturningUserService: ReturningUserServiceInterface {
     private let coreDataDeletionService: CoreDataDeletionServiceInterface
     private let localAuthenticationService: LocalAuthenticationServiceInterface
 
-    private var storedpersistentUserIdentifier: String? {
+    private var storedPersistentUserIdentifier: String? {
         try? openSecureStoreService.readItem(itemName: "persistentUserIdentifier")
     }
 
@@ -30,26 +30,24 @@ class ReturningUserService: ReturningUserServiceInterface {
             return .failure(.missingIdentifierError)
         }
 
-        if localAuthenticationService.authenticationOnboardingFlowSeen {
-            guard let storedIdentifier = storedpersistentUserIdentifier
-            else {
-                return .failure(.missingIdentifierError)
-            }
+        if localAuthenticationService.authenticationOnboardingFlowSeen,
+           let storedIdentifier = storedPersistentUserIdentifier {
             return await handleUserIdentifiers(
                 currentIdentifier: currentIdentifier,
                 storedIdentifier: storedIdentifier
             )
         } else {
-            return saveIdentifier(currentIdentifier: currentIdentifier, isReturningUser: true)
+            return saveIdentifier(
+                currentIdentifier: currentIdentifier,
+                isReturningUser: false
+            )
         }
     }
 
     private func currentPersistentUserIdentifier(idToken: String?) async -> String? {
         guard let idToken = idToken,
               let payload = try? await JWTExtractor().extract(jwt: idToken)
-        else {
-            return nil
-        }
+        else { return nil }
         return payload.sub
     }
 

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/AnalyticsServiceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/AnalyticsServiceTests.swift
@@ -120,6 +120,25 @@ struct AnalyticsServiceTests {
     }
 
     @Test
+    func trackError_rejectedPermissions_doesNothing() {
+        let mockAnalyticsClient = MockAnalyticsClient()
+        let mockUserDefaultsService = MockUserDefaultsService()
+        let mockAuthenticationService = MockAuthenticationService()
+        mockAuthenticationService._stubbedIsSignedIn = true
+        let subject = AnalyticsService(
+            clients: [mockAnalyticsClient],
+            userDefaultsService: mockUserDefaultsService,
+            authenticationService: mockAuthenticationService
+        )
+        subject.setAcceptedAnalytics(accepted: false)
+
+        let error = NSError(domain: "test", code: 1)
+        subject.track(error: error)
+
+        #expect(mockAnalyticsClient._trackErrorReceivedErrors.count == 0)
+    }
+
+    @Test
     func trackEvent_signedOut_doesNothing() {
         let mockAnalyticsClient = MockAnalyticsClient()
         let mockUserDefaults = MockUserDefaultsService()
@@ -155,6 +174,29 @@ struct AnalyticsServiceTests {
             analyticsService: subject
         )
         subject.track(screen: mockViewController)
+
+        #expect(mockAnalyticsClient._trackEventReceivedEvents.count == 0)
+    }
+
+    @Test
+    @MainActor
+    func trackError_signedOut_doesNothing() {
+        let mockAnalyticsClient = MockAnalyticsClient()
+        let mockUserDefaults = MockUserDefaultsService()
+        let mockAuthenticationService = MockAuthenticationService()
+        mockAuthenticationService._stubbedIsSignedIn = true
+        let subject = AnalyticsService(
+            clients: [mockAnalyticsClient],
+            userDefaultsService: mockUserDefaults,
+            authenticationService: mockAuthenticationService
+        )
+        subject.setAcceptedAnalytics(accepted: true)
+
+        let mockViewController = MockBaseViewController(
+            analyticsService: subject
+        )
+        let error = NSError(domain: "test", code: 1)
+        subject.track(error: error)
 
         #expect(mockAnalyticsClient._trackEventReceivedEvents.count == 0)
     }

--- a/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/ReturningUserServiceTests.swift
+++ b/Tests/govuk_ios/govuk_ios_unit_tests/Specs/Services/ReturningUserServiceTests.swift
@@ -20,7 +20,7 @@ struct ReturningUserServiceTests {
 
         await confirmation() { confirmation in
             if case let .success(isReturningUser) = result {
-                #expect(isReturningUser)
+                #expect(isReturningUser == false)
                 #expect(mockSecureStoreService._savedItems["persistentUserIdentifier"] != nil)
                 confirmation()
             }
@@ -122,7 +122,7 @@ struct ReturningUserServiceTests {
     }
 
     @Test
-    func process_missingStoredIdentifier_returnsFailure() async {
+    func process_missingStoredIdentifier_setsIsReturningUserFalse() async {
         let mockSecureStoreService = MockSecureStoreService()
         let mockCoreDataDeletionService = MockCoreDataDeletionService()
         let mockLocalAuthenticationService = MockLocalAuthenticationService()
@@ -136,8 +136,9 @@ struct ReturningUserServiceTests {
         let result = await sut.process(idToken: Self.idToken)
 
         await confirmation() { confirmation in
-            if case let .failure(error) = result {
-                #expect(error == .missingIdentifierError)
+            if case let .success(isReturningUser) = result {
+                #expect(isReturningUser == false)
+                #expect(mockSecureStoreService._savedItems["persistentUserIdentifier"] != nil)
                 confirmation()
             }
         }


### PR DESCRIPTION
If a user logs in and a previous id token isn't stored, rather than throw an error, just treat them as a new user.