### PR TITLE
Fix cancel behaviour on chat onboarding

### DIFF
--- a/Production/govuk_ios/Coordinators/TabCoordinator.swift
+++ b/Production/govuk_ios/Coordinators/TabCoordinator.swift
@@ -98,6 +98,7 @@ class TabCoordinator: BaseCoordinator,
     private func selectTabIndex(for navigationController: UINavigationController) {
         let index = tabController.viewControllers?.firstIndex(of: navigationController)
         tabController.selectedIndex = index ?? 0
+        previousTabIndex = currentTabIndex
         currentTabIndex = tabController.selectedIndex
     }
 


### PR DESCRIPTION
previousTabIndex wasn't being set when a deeplink was being processed (chat navigation from home screen), resulting in inconsistent tabs being selected when a user cancelled out from chat onboarding, now previousTabIndex is being set, the user will return to the original tab (in this case home screen from chat widget).